### PR TITLE
Simple fix to make the useragent not being overridden.

### DIFF
--- a/src/main/java/com/openshift/client/IHttpClient.java
+++ b/src/main/java/com/openshift/client/IHttpClient.java
@@ -52,6 +52,8 @@ public interface IHttpClient {
 	
 	public void setUserAgent(String userAgent);
 	
+	public String getUserAgent();
+	
 	public void setVersion(String serviceVersion);
 
 	public String get(URL url) throws HttpClientException, SocketTimeoutException;

--- a/src/main/java/com/openshift/internal/client/httpclient/UrlConnectionHttpClient.java
+++ b/src/main/java/com/openshift/internal/client/httpclient/UrlConnectionHttpClient.java
@@ -106,6 +106,10 @@ public class UrlConnectionHttpClient implements IHttpClient {
 		this.userAgent = userAgent;
 	}
 
+	public String getUserAgent() {
+		return userAgent;
+	}
+	
 	public void setVersion(String version) {
 		this.version = version;
 	}

--- a/src/main/java/com/openshift/internal/client/httpclient/UrlConnectionHttpClientBuilder.java
+++ b/src/main/java/com/openshift/internal/client/httpclient/UrlConnectionHttpClientBuilder.java
@@ -65,9 +65,15 @@ public class UrlConnectionHttpClientBuilder {
 	}
 
 	public IHttpClient client() {
-		if (authKey != null && authKey.trim().length() > 0)
-			userAgent = "OpenShift";
-		return new UrlConnectionHttpClient(username, password, userAgent, sslChecks, requestMediaType,
-				acceptedMediaType, version, authKey, authIV);
+		if (authKey != null && authKey.trim().length() > 0) {
+			if (userAgent == null) {
+				userAgent = "OpenShift";
+			} else if (!userAgent.startsWith("OpenShift")) {
+				userAgent = "OpenShift-" + userAgent;
+			}
+		}
+		return new UrlConnectionHttpClient(username, password, userAgent,
+				sslChecks, requestMediaType, acceptedMediaType, version,
+				authKey, authIV);
 	}
 }

--- a/src/test/java/com/openshift/internal/client/HttpClientTest.java
+++ b/src/test/java/com/openshift/internal/client/HttpClientTest.java
@@ -127,6 +127,24 @@ public class HttpClientTest {
 		assertNotNull(response);
 		assertTrue(response.indexOf(ACCEPT_APPLICATION_JSON) > 0);
 	}
+	
+	@Test
+	public void hasProperAgentWhenUsingKeys() {
+		httpClient = new UrlConnectionHttpClientBuilder()
+		.setUserAgent("com.needskey").setCredentials("blah", "bluh", "authkey", "authiv")
+		.client();
+		
+		assertEquals("OpenShift-com.needskey", httpClient.getUserAgent());
+	}
+
+	@Test
+	public void hasProperAgentWhenUsingKeysAndNoAgent() {
+		httpClient = new UrlConnectionHttpClientBuilder()
+		 .setCredentials("blah", "bluh", "authkey", "authiv")
+		.client();
+		
+		assertEquals("OpenShift", httpClient.getUserAgent());
+	}
 
 	@Test
 	public void shouldEncodeParametersCorrectly() throws HttpClientException, FileNotFoundException, IOException,


### PR DESCRIPTION
But this just doesn't seem right - shouldn't the client only do this if
sslChecks==true ?! Why both authkey/authiv and sslchecks booleans ?
