### PR TITLE
[JBIDE-13522] may now read configurations with doublequoted values

### DIFF
--- a/src/main/java/com/openshift/client/configuration/AbstractOpenshiftConfiguration.java
+++ b/src/main/java/com/openshift/client/configuration/AbstractOpenshiftConfiguration.java
@@ -35,9 +35,9 @@ public abstract class AbstractOpenshiftConfiguration implements IOpenShiftConfig
 	protected static final String KEY_PASSWORD = "rhpassword";
 	protected static final String KEY_CLIENT_ID = "client_id";
 	
-	private static final Pattern SINGLEQUOTED_REGEX = Pattern.compile("'*([^']+)'*");
+	private static final Pattern QUOTED_REGEX = Pattern.compile("['\"]*([^'\"]+)['\"]*");
 	private static final char SINGLEQUOTE = '\'';
-	
+		
 	private static final String SYSPROPERTY_PROXY_PORT = "proxyPort";
 	private static final String SYSPROPERTY_PROXY_HOST = "proxyHost";
 	private static final String SYSPROPERTY_PROXY_SET = "proxySet";
@@ -120,7 +120,7 @@ public abstract class AbstractOpenshiftConfiguration implements IOpenShiftConfig
 	}
 
 	public String getRhlogin() {
-		return removeSingleQuotes(properties.getProperty(KEY_RHLOGIN));
+		return removeQuotes(properties.getProperty(KEY_RHLOGIN));
 	}
 
 	public void setLibraServer(String libraServer) {
@@ -128,7 +128,7 @@ public abstract class AbstractOpenshiftConfiguration implements IOpenShiftConfig
 	}
 
 	public String getLibraServer() {
-		return UrlUtils.ensureStartsWithHttps(removeSingleQuotes(properties.getProperty(KEY_LIBRA_SERVER)));
+		return UrlUtils.ensureStartsWithHttps(removeQuotes(properties.getProperty(KEY_LIBRA_SERVER)));
 	}
 
 	public void setLibraDomain(String libraDomain) {
@@ -136,18 +136,18 @@ public abstract class AbstractOpenshiftConfiguration implements IOpenShiftConfig
 	}
 
 	public String getLibraDomain() {
-		return removeSingleQuotes(properties.getProperty(KEY_LIBRA_DOMAIN));
+		return removeQuotes(properties.getProperty(KEY_LIBRA_DOMAIN));
 	}
 
 	protected String ensureIsSingleQuoted(String value) {
-		return SINGLEQUOTE + removeSingleQuotes(value) + SINGLEQUOTE;
+		return SINGLEQUOTE + removeQuotes(value) + SINGLEQUOTE;
 	}
 
-	protected String removeSingleQuotes(String value) {
+	protected String removeQuotes(String value) {
 		if (value == null) {
 			return null;
 		}
-		Matcher matcher = SINGLEQUOTED_REGEX.matcher(value);
+		Matcher matcher = QUOTED_REGEX.matcher(value);
 		if (matcher.find()
 				&& matcher.groupCount() == 1) {
 			return matcher.group(1);
@@ -172,17 +172,17 @@ public abstract class AbstractOpenshiftConfiguration implements IOpenShiftConfig
 		String set = properties.getProperty(SYSPROPERTY_PROXY_SET);
 		
 		if (set != null)
-			return Boolean.parseBoolean(removeSingleQuotes(set));
+			return Boolean.parseBoolean(removeQuotes(set));
 		else 
 			return false;
 	}
 	
 	public String getProxyHost() {
-		return removeSingleQuotes(properties.getProperty(SYSPROPERTY_PROXY_HOST));
+		return removeQuotes(properties.getProperty(SYSPROPERTY_PROXY_HOST));
 	}
 	
 	public String getProxyPort() {
-		return removeSingleQuotes(properties.getProperty(SYSPROPERTY_PROXY_PORT));
+		return removeQuotes(properties.getProperty(SYSPROPERTY_PROXY_PORT));
 	}
 
 }

--- a/src/test/java/com/openshift/internal/client/ConfigurationTest.java
+++ b/src/test/java/com/openshift/internal/client/ConfigurationTest.java
@@ -47,6 +47,8 @@ public class ConfigurationTest {
 	private static final String USERNAME3 = "Dietisheim";
 	private static final String ANOTHER_USERNAME = "anotherUser";
 	protected static final String LIBRA_SERVER = "openshift.redhat.com";
+	protected static final String SIGLEQUOTED_LIBRA_SERVER = "'openshift.redhat.com'";
+	protected static final String DOUBLEQUOTED_LIBRA_SERVER = "\"openshift.redhat.com\"";
 
 	@Test
 	public void versionTest() throws OpenShiftException, IOException {
@@ -163,7 +165,20 @@ public class ConfigurationTest {
 		SystemConfiguration systemConfiguration = new SystemConfigurationFake(new DefaultConfiguration()) {
 
 			protected void init(Properties properties) {
-				properties.put(KEY_RHLOGIN, USERNAME);
+				properties.put(KEY_LIBRA_SERVER, SIGLEQUOTED_LIBRA_SERVER);
+			}
+
+		};
+		UserConfigurationFake userConfiguration = new UserConfigurationFake(systemConfiguration);
+		assertEquals(UrlUtils.SCHEME_HTTPS + LIBRA_SERVER, userConfiguration.getLibraServer());
+	}
+
+	@Test
+	public void doubleQuotedLibraServerIsReturnedWithoutQuotes() throws OpenShiftException, IOException {
+		SystemConfiguration systemConfiguration = new SystemConfigurationFake(new DefaultConfiguration()) {
+
+			protected void init(Properties properties) {
+				properties.put(KEY_LIBRA_SERVER, DOUBLEQUOTED_LIBRA_SERVER);
 			}
 
 		};
@@ -176,7 +191,7 @@ public class ConfigurationTest {
 		SystemConfiguration systemConfiguration = new SystemConfigurationFake(new DefaultConfiguration()) {
 
 			protected void init(Properties properties) {
-				properties.put(KEY_RHLOGIN, USERNAME);
+				properties.put(KEY_LIBRA_SERVER, LIBRA_SERVER);
 			}
 
 		};


### PR DESCRIPTION
Lately rhc tooling started creating express.conf(s) with double quoted
values (before they used single quotes). We could not handle those. Now
we can.
