### PR TITLE
[JBIDE-13559] switched client back to protocol 1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 	<!-- Artifact Information -->
 	<groupId>com.openshift</groupId>
 	<artifactId>openshift-java-client</artifactId>
-	<version>2.0.3-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>OpenShift Java Client</name>
 	<url>http://openshift.redhat.com</url>

--- a/src/main/java/com/openshift/client/IApplication.java
+++ b/src/main/java/com/openshift/client/IApplication.java
@@ -428,7 +428,4 @@ public interface IApplication extends IOpenShiftResource {
 	public List<String> getEnvironmentProperties() throws OpenShiftSSHOperationException;
 	
 	public String getCartridge(String cartridgeName) throws OpenShiftException;
-	
-	public String getLogDirEnvName(String cartridgeName) throws OpenShiftException;
-
 }

--- a/src/main/java/com/openshift/internal/client/ApplicationResource.java
+++ b/src/main/java/com/openshift/internal/client/ApplicationResource.java
@@ -19,7 +19,6 @@ import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -29,9 +28,15 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
 import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
 
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ChannelExec;
@@ -65,14 +70,6 @@ import com.openshift.internal.client.ssh.ApplicationPortForwarding;
 import com.openshift.internal.client.utils.Assert;
 import com.openshift.internal.client.utils.CollectionUtils;
 import com.openshift.internal.client.utils.IOpenShiftJsonConstants;
-
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
-
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.DefaultHandler;
 
 /**
  * The Class Application.
@@ -524,28 +521,6 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 		return new GetCartridgeRequest().execute(cartridgeName);
 
 	}
-	
-	public String getLogDirEnvName(String cartridgeName) throws OpenShiftException {
-		Assert.notNull(cartridgeName);
-
-		String xml = getCartridge(cartridgeName);
-		
-		CartridgeSAXParser parser = new CartridgeSAXParser();
-		parser.parseDocument(xml);
-		
-		Properties props = parser.getProperties();
-				
-		Enumeration i = props.propertyNames();
-		while (i.hasMoreElements()){
-			String key = (String)i.nextElement();
-			String value = props.getProperty(key);
-			if (value.toLowerCase().contains("log files"))
-				return key;
-		}
-		
-		return null;
-	}
-
 
 	protected IOpenShiftConnection getConnection() {
 		return getDomain().getUser().getConnection();

--- a/src/main/java/com/openshift/internal/client/RestService.java
+++ b/src/main/java/com/openshift/internal/client/RestService.java
@@ -56,7 +56,7 @@ public class RestService implements IRestService {
 	private static final String SYSPROPERTY_PROXY_HOST = "proxyHost";
 	private static final String SYSPROPERTY_PROXY_SET = "proxySet";
 
-	private static final String SERVICE_VERSION = "1.1";
+	private static final String SERVICE_VERSION = "1.0";
 
 	private String baseUrl;
 	private IHttpClient client;

--- a/src/test/java/com/openshift/internal/client/ApplicationResourceIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/client/ApplicationResourceIntegrationTest.java
@@ -11,10 +11,8 @@
 package com.openshift.internal.client;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 
@@ -60,25 +58,6 @@ public class ApplicationResourceIntegrationTest {
 	@AfterClass
 	public static void cleanup() {
 		ApplicationTestUtils.silentlyDestroyAllApplications(domain);
-	}
-	
-	@Test
-	public void testLog() throws Exception {
-		
-		try {
-		
-			ApplicationTestUtils.silentlyDestroy1Application(domain);
-			String applicationName =
-					ApplicationTestUtils.createRandomApplicationName();
-			IApplication application = 
-					domain.createApplication(applicationName, ICartridge.JBOSSAS_7);
-						
-			assertEquals(application.getLogDirEnvName("jbossas-7"), "OPENSHIFT_JBOSSAS_LOG_DIR");
-		
-		} catch (Exception e) {
-			e.printStackTrace();
-			throw e;
-		}
 	}
 	
 	@Test


### PR DESCRIPTION
Switched client back to enforce protocol 1.0, removed IApplication#getLogDirEnvName
(since not a good impl, and requires protocol 1.1)
