### PR TITLE
[JBIDE-13675] replaced silentlyDestroyAllDomains by #destroyAllDomains

### DIFF
--- a/src/test/java/com/openshift/client/utils/DomainTestUtils.java
+++ b/src/test/java/com/openshift/client/utils/DomainTestUtils.java
@@ -21,16 +21,12 @@ import com.openshift.client.OpenShiftException;
  */
 public class DomainTestUtils {
 
-	public static void silentlyDestroyAllDomains(IUser user) {
+	public static void destroyAllDomains(IUser user) {
 		if (user == null) {
 			return;
 		}
-		try {
-			for (IDomain domain : user.getDomains()) {
-				silentlyDestroy(domain);
-			}
-		} catch (Exception e) {
-//			e.printStackTrace();
+		for (IDomain domain : user.getDomains()) {
+			domain.destroy(true);
 		}
 	}
 

--- a/src/test/java/com/openshift/internal/client/UserResourceIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/client/UserResourceIntegrationTest.java
@@ -64,7 +64,7 @@ public class UserResourceIntegrationTest {
 	@Test
 	public void shouldReturnNoDomains() throws OpenShiftException {
 		// precondition
-		DomainTestUtils.silentlyDestroyAllDomains(user);
+		DomainTestUtils.destroyAllDomains(user);
 		// operation
 		List<IDomain> domains = user.getDomains();
 		// verification
@@ -75,7 +75,7 @@ public class UserResourceIntegrationTest {
 	public void shouldCreateDomain() throws OpenShiftException {
 		// pre-condition
 		// cannot create domain if there's already one
-		DomainTestUtils.silentlyDestroyAllDomains(user);
+		DomainTestUtils.destroyAllDomains(user);
 		
 		// operation
 		String id = DomainTestUtils.createRandomName();
@@ -124,7 +124,7 @@ public class UserResourceIntegrationTest {
 	@Test
 	public void shouldReturnThatHasNoDomain() throws OpenShiftException {
 		// precondition
-		DomainTestUtils.silentlyDestroyAllDomains(user);
+		DomainTestUtils.destroyAllDomains(user);
 		// operation
 		Boolean hasDomain = user.hasDomain();
 		// verification
@@ -154,7 +154,7 @@ public class UserResourceIntegrationTest {
 	@Test
 	public void shouldReturnEmptyDomains() throws OpenShiftException {
 		// precondition
-		DomainTestUtils.silentlyDestroyAllDomains(user);
+		DomainTestUtils.destroyAllDomains(user);
 		// operation
 		List<IDomain> domains = user.getDomains();
 		// verification
@@ -169,7 +169,7 @@ public class UserResourceIntegrationTest {
 		assertNotNull(domain);
 
 		IUser otherUser = new TestConnectionFactory().getConnection().getUser();
-		DomainTestUtils.silentlyDestroyAllDomains(otherUser);
+		DomainTestUtils.destroyAllDomains(otherUser);
 		assertNull(otherUser.getDefaultDomain());
 		
 		// operation


### PR DESCRIPTION
implemented DomainTestUtils.destroyAllDomains() and replaced usage of
DomainTestUtils.silentlyDestroyAllDomains() by it so that domain deletion
errors are not swallowed any more. Domain deletion is a pre-condition
in these UserResourceIntegrationTest
