### PR TITLE
[JBIDE-13761] removed IUser#getAuthKey and IUser#getAuthIV

### DIFF
--- a/src/main/java/com/openshift/client/IUser.java
+++ b/src/main/java/com/openshift/client/IUser.java
@@ -25,11 +25,7 @@ public interface IUser extends IOpenShiftResource {
 	public String getPassword();
 
 	public String getServer();
-	
-	public String getAuthKey();
-	
-	public String getAuthIV();
-	
+		
 	public IOpenShiftConnection getConnection();
 
 	public IDomain createDomain(String id) throws OpenShiftException;

--- a/src/main/java/com/openshift/internal/client/UserResource.java
+++ b/src/main/java/com/openshift/internal/client/UserResource.java
@@ -74,16 +74,6 @@ public class UserResource extends AbstractOpenShiftResource implements IUser {
 		return consumedGears;
 	}
 
-	public String getAuthKey() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	public String getAuthIV() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
 	public IDomain createDomain(String id) throws OpenShiftException {
 		Assert.notNull(id);
 		


### PR DESCRIPTION
In UserResource/IUser there are still #getAuthIV #getAuthKey methods that we inherited from the legacy client. They're currently not implement and return <code>null</code>. In the new client the auth keys are passed over to the http client via connection builder. They're not handled by the user any more. We should simply get rid of them.
