### PR TITLE
[JBIDE-13794] removed server url from HttpClientException

### DIFF
--- a/src/main/java/com/openshift/internal/client/httpclient/UrlConnectionHttpClient.java
+++ b/src/main/java/com/openshift/internal/client/httpclient/UrlConnectionHttpClient.java
@@ -180,7 +180,7 @@ public class UrlConnectionHttpClient implements IHttpClient {
 			throws SocketTimeoutException {
 		try {
 			int responseCode = connection.getResponseCode();
-			String errorMessage = createErrorMessage(connection);
+			String errorMessage = StreamUtils.readToString(connection.getErrorStream());
 			switch (responseCode) {
 			case STATUS_INTERNAL_SERVER_ERROR:
 				return new InternalServerErrorException(errorMessage, ioe);
@@ -199,21 +199,6 @@ public class UrlConnectionHttpClient implements IHttpClient {
 			return new HttpClientException(e);
 		}
 	}
-
-	protected String createErrorMessage(HttpURLConnection connection) throws IOException {
-		StringBuilder builder = new StringBuilder("Connection to ")
-			.append(connection.getURL());
-		String reason = connection.getResponseMessage();
-		if (!StringUtils.isEmpty(reason)) {
-			builder.append(": ").append(reason);
-		}
-		String errorMessage = StreamUtils.readToString(connection.getErrorStream());
-		if (!StringUtils.isEmpty(errorMessage)) {
-			builder.append(", ").append(errorMessage);
-		}
-		return builder.toString();
-	}
-
 
 	private boolean isHttps(URL url) {
 		return "https".equals(url.getProtocol());

--- a/src/test/java/com/openshift/internal/client/DomainResourceIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/client/DomainResourceIntegrationTest.java
@@ -81,7 +81,7 @@ public class DomainResourceIntegrationTest {
 	}
 
 	@Test
-	public void shouldNotDeleteDomainWithApplications() throws OpenShiftException, SocketTimeoutException {
+	public void shouldNotDeleteDomainWithApplications() throws OpenShiftException {
 		IDomain domain = null;
 		try {
 			// pre-condition


### PR DESCRIPTION
Removed server url (-error message) from HttpClientException since this is
preventing users from getting the json from the wrapping
OpenShiftEndpointException. Made sure the OpenshiftTimeoutException reports
the full server url.
