### PR TITLE
[RHBZ-917656] Fix license field in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
 	<!-- Licenses -->
 	<licenses>
 		<license>
-			<name>Apache License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<name>Eclipse Public License v1.0</name>
+			<url>http://www.eclipse.org/legal/epl-v10.html</url>
 		</license>
 	</licenses>
 


### PR DESCRIPTION
License listed in POM is Apache, code is EPL.
https://bugzilla.redhat.com/show_bug.cgi?id=917656
