### PR TITLE
[JBIDE-13888] fixed user agent not being built from properties

### DIFF
--- a/src/main/java/com/openshift/internal/client/RestService.java
+++ b/src/main/java/com/openshift/internal/client/RestService.java
@@ -58,9 +58,13 @@ public class RestService implements IRestService {
 	private IHttpClient client;
 
 	public RestService(String baseUrl, String clientId, IHttpClient client) {
+		this(baseUrl, clientId, client, new RestServiceProperties());
+	}
+
+	RestService(String baseUrl, String clientId, IHttpClient client, RestServiceProperties properties) {
 		this.baseUrl = UrlUtils.ensureStartsWithHttps(baseUrl);
 		this.client = client;
-		client.setUserAgent(new RestServiceProperties().getUseragent(clientId));
+		client.setUserAgent(properties.getUseragent(clientId));
 		client.setVersion(SERVICE_VERSION);
 	}
 

--- a/src/main/java/com/openshift/internal/client/RestServiceProperties.java
+++ b/src/main/java/com/openshift/internal/client/RestServiceProperties.java
@@ -26,10 +26,10 @@ public class RestServiceProperties {
 
 	private static final String PROPERTIES_FILE = "restservice.properties";
 
-	private static final String KEY_USERAGENTPATTERN = "useragent";
-	private static final String KEY_VERSION = "version";
-	private static final String KEY_CLIENTID = "clientid";
-
+	static final String KEY_USERAGENTPATTERN = "useragent";
+	static final String KEY_VERSION = "version";
+	static final String KEY_CLIENTID = "clientid";
+	
 	private String version;
 	private String userAgent;
 	private String clientId;
@@ -52,14 +52,15 @@ public class RestServiceProperties {
 	}
 
 	public String getUseragent(String id) {
+		String userAgent = null;
 		String version = getVersion();
 		String useragentPattern = getUseragentPattern();
 		if (!StringUtils.isEmpty(id)
 				&& !StringUtils.isEmpty(version)
 				&& !StringUtils.isEmpty(useragentPattern)) {
-			String userAgent = MessageFormat.format(getUseragentPattern(), getVersion(), id);
+			userAgent = MessageFormat.format(getUseragentPattern(), getVersion(), id);
 		}
-		return null;
+		return userAgent;
 	}
 
 	protected String getUseragentPattern() {
@@ -78,7 +79,7 @@ public class RestServiceProperties {
 		return clientId;
 	}
 
-	private Properties getProperties() throws IOException {
+	protected Properties getProperties() throws IOException {
 		if (properties == null) {
 			InputStream in = null;
 			try {

--- a/src/test/java/com/openshift/internal/client/OpenShiftTestSuite.java
+++ b/src/test/java/com/openshift/internal/client/OpenShiftTestSuite.java
@@ -19,6 +19,7 @@ import com.openshift.internal.client.response.ResourceDTOFactoryTest;
 @Suite.SuiteClasses({
 	ConfigurationTest.class,
 	HttpClientTest.class,
+	RestServicePropertiesTest.class,
 	RestServiceTest.class,
 	ResourceDTOFactoryTest.class,
 	DomainResourceTest.class,


### PR DESCRIPTION
Corrected the erroneous code that would always return <code>null</code>
when reading the user agent pattern from the properties. Added
RestServicePropertiesTest and RestServiceTest#shouldSetUserAgentToHttpClient
