### PR TITLE
[JBIDE-14701] RestResponse#getMessages are now iterable in a fixed order

### DIFF
--- a/src/main/java/com/openshift/client/Message.java
+++ b/src/main/java/com/openshift/client/Message.java
@@ -20,6 +20,7 @@ import com.openshift.internal.client.utils.StringUtils;
  */
 public class Message {
 
+	public static final String FIELD_DEFAULT = null;
 	public static final String FIELD_RESULT = "result";
 	public static final String FIELD_APPINFO = "appinfo";
 	

--- a/src/main/java/com/openshift/client/OpenShiftEndpointException.java
+++ b/src/main/java/com/openshift/client/OpenShiftEndpointException.java
@@ -66,6 +66,24 @@ public class OpenShiftEndpointException extends OpenShiftException {
 		return null;
 	}
 	
+	/**
+	 * Returns the message for the given field. Returns <code>null</code> otherwise.
+	 * 
+	 * @param field
+	 * @return the message for the given field
+	 * 
+	 * @see Message#FIELD_DEFAULT
+	 * @see Message#FIELD_APPINFO
+	 * @see Message#FIELD_RESULT
+	 */
+	public Message getRestResponseMessage(String field) {
+		Map<String, Message> messages = getRestResponseMessages();
+		if (messages == null) {
+			return null;
+		}
+		return messages.get(field);
+	}
+
 	protected String getUrl() {
 		return url;
 	}

--- a/src/main/java/com/openshift/internal/client/RestService.java
+++ b/src/main/java/com/openshift/internal/client/RestService.java
@@ -122,13 +122,13 @@ public class RestService implements IRestService {
 
 	private String getResponseMessage(HttpClientException clientException) {
 		try {
-			StringBuilder builder = new StringBuilder();
 			RestResponse restResponse = ResourceDTOFactory.get(clientException.getMessage());
 			if (restResponse == null) {
 				return null;
 			}
-			for (Map.Entry<String, Message> entry : restResponse.getMessages().entrySet()) {
-				builder.append(entry.toString()).append('\n');
+			StringBuilder builder = new StringBuilder();
+			for (Message message : restResponse.getMessages().values()) {
+				builder.append(message.getText()).append('\n');
 			}
 			return builder.toString();
 		} catch (OpenShiftException e) {

--- a/src/main/java/com/openshift/internal/client/response/ResourceDTOFactory.java
+++ b/src/main/java/com/openshift/internal/client/response/ResourceDTOFactory.java
@@ -45,6 +45,7 @@ import static com.openshift.internal.client.utils.IOpenShiftJsonConstants.PROPER
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -140,7 +141,7 @@ public class ResourceDTOFactory {
 	 * @return the list< string>
 	 */
 	private static Map<String, Message> createMessages(ModelNode messagesNode) {
-		Map<String, Message> messages = new HashMap<String, Message>();
+		Map<String, Message> messages = new LinkedHashMap<String, Message>();
 		if (messagesNode.getType() == ModelType.LIST) {
 			for (ModelNode messageNode : messagesNode.asList()) {
 				Message message = createMessage(messageNode);

--- a/src/main/java/com/openshift/internal/client/response/RestResponse.java
+++ b/src/main/java/com/openshift/internal/client/response/RestResponse.java
@@ -55,6 +55,7 @@ public class RestResponse {
 		return status;
 	}
 
+
 	/**
 	 * Gets the messages.
 	 *

--- a/src/test/java/com/openshift/client/utils/MessageAssert.java
+++ b/src/test/java/com/openshift/client/utils/MessageAssert.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package com.openshift.client.utils;
 
+import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import org.fest.assertions.AssertExtension;
@@ -26,6 +27,11 @@ public class MessageAssert implements AssertExtension {
 
 	public MessageAssert(Message message) {
 		this.message = message;
+	}
+
+	public MessageAssert hasText() {
+		assertThat(message.getText()).isNotEmpty();
+		return this;
 	}
 
 	public MessageAssert hasText(String text) {

--- a/src/test/java/com/openshift/internal/client/DomainResourceIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/client/DomainResourceIntegrationTest.java
@@ -27,6 +27,8 @@ import com.openshift.client.IApplication;
 import com.openshift.client.IDomain;
 import com.openshift.client.IGearProfile;
 import com.openshift.client.IUser;
+import com.openshift.client.Message;
+import com.openshift.client.Message.Severity;
 import com.openshift.client.OpenShiftEndpointException;
 import com.openshift.client.OpenShiftException;
 import com.openshift.client.cartridge.IStandaloneCartridge;
@@ -34,6 +36,7 @@ import com.openshift.client.cartridge.selector.LatestVersionOf;
 import com.openshift.client.utils.ApplicationAssert;
 import com.openshift.client.utils.ApplicationTestUtils;
 import com.openshift.client.utils.DomainTestUtils;
+import com.openshift.client.utils.MessageAssert;
 import com.openshift.client.utils.StringUtils;
 import com.openshift.client.utils.TestConnectionFactory;
 
@@ -102,7 +105,6 @@ public class DomainResourceIntegrationTest {
 		}
 	}
 
-	@Ignore
 	@Test
 	public void shouldReportErrorCode128() throws OpenShiftException {
 		IDomain domain = null;
@@ -117,10 +119,11 @@ public class DomainResourceIntegrationTest {
 			fail("OpenShiftEndpointException did not occurr");
 		} catch (OpenShiftEndpointException e) {
 			// verification
-			assertThat(e.getRestResponse()).isNotNull();
-			assertThat(e.getRestResponse().getMessages()).isNotEmpty();
-			assertThat(e.getRestResponse().getMessages().get(0)).isNotNull();
-			assertThat(e.getRestResponse().getMessages().get(0).getExitCode()).isEqualTo(128);
+			assertThat(e.getRestResponseMessages().size()).isEqualTo(1);
+			new MessageAssert(e.getRestResponseMessage(Message.FIELD_DEFAULT))
+					.hasExitCode(128)
+					.hasSeverity(Severity.ERROR)
+					.hasText();
 		}
 	}
 

--- a/src/test/java/com/openshift/internal/client/response/ResourceDTOFactoryTest.java
+++ b/src/test/java/com/openshift/internal/client/response/ResourceDTOFactoryTest.java
@@ -15,6 +15,7 @@ import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -25,6 +26,8 @@ import org.junit.Test;
 import com.openshift.client.GearState;
 import com.openshift.client.HttpMethod;
 import com.openshift.client.IGear;
+import com.openshift.client.Message;
+import com.openshift.client.utils.MessageAssert;
 import com.openshift.client.utils.Samples;
 import com.openshift.internal.client.CartridgeType;
 
@@ -201,7 +204,8 @@ public class ResourceDTOFactoryTest {
 
 	/**
 	 * Should unmarshall get application response body.
-	 * @throws Throwable 
+	 * 
+	 * @throws Throwable
 	 */
 	@Test
 	public void shouldUnmarshallGetApplicationWithAliasesResponseBody() throws Throwable {
@@ -231,10 +235,32 @@ public class ResourceDTOFactoryTest {
 		// pre-conditions
 		String content = Samples.POST_MYSQL_DOMAINS_FOOBARZ_APPLICATIONS_SPRINGEAP6_CARTRIDGES.getContentAsString();
 		assertNotNull(content);
+
 		// operation
 		RestResponse response = ResourceDTOFactory.get(content);
+
 		// verifications
-		assertThat(response.getMessages()).hasSize(3);
+		Collection<Message> messages = response.getMessages().values();
+		assertThat(messages).hasSize(3);
+		Iterator<Message> it = messages.iterator();
+		new MessageAssert(it.next())
+				.hasField(Message.FIELD_DEFAULT)
+				.hasExitCode(-1)
+				.hasText("Added mysql-5.1 to application springeap6");
+		new MessageAssert(it.next())
+				.hasField(Message.FIELD_RESULT)
+				.hasExitCode(0)
+				.hasText(
+						"\nMySQL 5.1 database added.  Please make note of these credentials:\n\n"
+								+ "       Root User: adminnFC22YQ\n   Root Password: U1IX8AIlrEcl\n   Database Name: springeap6\n\n"
+								+ "Connection URL: mysql://$OPENSHIFT_MYSQL_DB_HOST:$OPENSHIFT_MYSQL_DB_PORT/\n\n"
+								+ "You can manage your new MySQL database by also embedding phpmyadmin-3.4.\n"
+								+ "The phpmyadmin username and password will be the same as the MySQL credentials above.\n");
+		new MessageAssert(it.next())
+				.hasField(Message.FIELD_APPINFO)
+				.hasExitCode(0)
+				.hasText("Connection URL: mysql://127.13.125.1:3306/\n");
+
 		assertThat(response.getDataType()).isEqualTo(EnumDataType.cartridge);
 		final CartridgeResourceDTO cartridge = response.getData();
 		assertThat(cartridge.getName()).isEqualTo("mysql-5.1");
@@ -245,7 +271,8 @@ public class ResourceDTOFactoryTest {
 
 	/**
 	 * Should unmarshall get application response body.
-	 * @throws Throwable 
+	 * 
+	 * @throws Throwable
 	 */
 	@Test
 	public void shouldUnmarshallGetApplicationCartridgesWith1ElementResponseBody() throws Throwable {
@@ -264,7 +291,8 @@ public class ResourceDTOFactoryTest {
 
 	/**
 	 * Should unmarshall get application response body.
-	 * @throws Throwable 
+	 * 
+	 * @throws Throwable
 	 */
 	@Test
 	public void shouldUnmarshallGetApplicationCartridgesWith3ElementsResponseBody() throws Throwable {
@@ -295,7 +323,7 @@ public class ResourceDTOFactoryTest {
 		assertThat(gearGroup.getName()).isEqualTo("514207b84382ec1fef0000ab");
 		assertThat(gearGroup.getUuid()).isEqualTo("514207b84382ec1fef0000ab");
 		assertThat(gearGroup.getGears()).hasSize(2);
-		final IGear gear = gearGroup.getGears().iterator().next(); 
+		final IGear gear = gearGroup.getGears().iterator().next();
 		assertThat(gear.getId()).isEqualTo("514207b84382ec1fef000098");
 		assertThat(gear.getState()).isEqualTo(GearState.IDLE);
 	}


### PR DESCRIPTION
Using LinkeHashmap when storing response messages so that messages are
now iterated upon in a fixed order which mappers when messages are
concatenated to exception message
