### PR TITLE
Add support for downloadable cartridges.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,11 @@
 			<artifactId>jsch</artifactId>
 			<version>0.1.44-1</version>
 		</dependency>
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+            <version>1.9.10</version>
+        </dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/src/main/java/com/openshift/client/IHttpClient.java
+++ b/src/main/java/com/openshift/client/IHttpClient.java
@@ -15,7 +15,9 @@ import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.util.Map;
 
+import com.openshift.internal.client.httpclient.EncodingException;
 import com.openshift.internal.client.httpclient.HttpClientException;
+import com.openshift.internal.client.httpclient.IMediaType;
 
 /**
  * @author André Dietisheim
@@ -67,21 +69,32 @@ public interface IHttpClient {
 
     public String get(URL url, int timeout) throws HttpClientException, SocketTimeoutException;
 
-	public String post(Map<String, Object> parameters, URL url) throws HttpClientException, SocketTimeoutException, UnsupportedEncodingException;
+	public String post(Map<String, Object> parameters, URL url) throws HttpClientException, SocketTimeoutException, EncodingException;
 
-    public String post(Map<String, Object> parameters, URL url, int timeout) throws HttpClientException, SocketTimeoutException, UnsupportedEncodingException;
+    public String post(Map<String, Object> parameters, URL url, int timeout) throws HttpClientException, SocketTimeoutException, EncodingException;
 
-	public String put(Map<String, Object> parameters, URL url) throws HttpClientException, SocketTimeoutException, UnsupportedEncodingException;
+    public String post(Map<String, Object> parameters, URL url, int timeout, IMediaType mediaType) throws HttpClientException, SocketTimeoutException, EncodingException;
 
-    public String put(Map<String, Object> parameters, URL url, int timeout) throws HttpClientException, SocketTimeoutException, UnsupportedEncodingException;
+	public String put(Map<String, Object> parameters, URL url) throws HttpClientException, SocketTimeoutException, EncodingException;
 
-	public String delete(Map<String, Object> parameters, URL url) throws HttpClientException, SocketTimeoutException, UnsupportedEncodingException;
+    public String put(Map<String, Object> parameters, URL url, int timeout) throws HttpClientException, SocketTimeoutException, EncodingException;
 
-    public String delete(Map<String, Object> parameters, URL url, int timeout) throws HttpClientException, SocketTimeoutException, UnsupportedEncodingException;
+    public String put(Map<String, Object> parameters, URL url, int timeout, IMediaType mediaType) throws HttpClientException, SocketTimeoutException, EncodingException;
+
+	public String delete(Map<String, Object> parameters, URL url) throws HttpClientException, SocketTimeoutException, EncodingException;
+
+    public String delete(Map<String, Object> parameters, URL url, int timeout) throws HttpClientException, SocketTimeoutException, EncodingException;
+
+    public String delete(Map<String, Object> parameters, URL url, int timeout, IMediaType mediaType) throws HttpClientException, SocketTimeoutException, EncodingException;
 
 	public String delete(URL url) throws HttpClientException, SocketTimeoutException, UnsupportedEncodingException;
 	
 	public void setAcceptedMediaType(String acceptedMediaType);
 	
 	public String getAcceptedMediaType();
+
+    public void setRequestMediaType(IMediaType requestMediaType);
+
+    public IMediaType getRequestMediaType();
+
 }

--- a/src/main/java/com/openshift/internal/client/AbstractOpenShiftResource.java
+++ b/src/main/java/com/openshift/internal/client/AbstractOpenShiftResource.java
@@ -18,6 +18,7 @@ import com.openshift.client.Message;
 import com.openshift.client.Messages;
 import com.openshift.client.OpenShiftException;
 import com.openshift.client.OpenShiftRequestException;
+import com.openshift.internal.client.httpclient.IMediaType;
 import com.openshift.internal.client.response.Link;
 import com.openshift.internal.client.response.RestResponse;
 
@@ -122,10 +123,22 @@ public abstract class AbstractOpenShiftResource implements IOpenShiftResource {
 		protected <DTO> DTO execute(ServiceParameter... parameters) throws OpenShiftException {
 			return execute(IHttpClient.NO_TIMEOUT, parameters);
 		}
-		
-		protected <DTO> DTO execute(int timeout, ServiceParameter... parameters) throws OpenShiftException {
+        protected <DTO> DTO execute(int timeout, ServiceParameter... parameters) throws OpenShiftException {
+            Link link = getLink(linkName);
+            RestResponse response = getService().request(link, timeout, parameters);
+
+            // in some cases, there is not response body, just a return code to
+            // indicate that the operation was successful (e.g.: delete domain)
+            if (response == null) {
+                return null;
+            }
+
+            return response.getData();
+        }
+
+		protected <DTO> DTO execute(int timeout, IMediaType mediaType, ServiceParameter... parameters) throws OpenShiftException {
 			Link link = getLink(linkName);
-			RestResponse response = getService().request(link, timeout, parameters);
+			RestResponse response = getService().request(link, timeout, mediaType, parameters);
 			
 			// in some cases, there is not response body, just a return code to
 			// indicate that the operation was successful (e.g.: delete domain)

--- a/src/main/java/com/openshift/internal/client/DomainResource.java
+++ b/src/main/java/com/openshift/internal/client/DomainResource.java
@@ -11,7 +11,9 @@
 package com.openshift.internal.client;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -23,7 +25,9 @@ import com.openshift.client.IHttpClient;
 import com.openshift.client.IUser;
 import com.openshift.client.Messages;
 import com.openshift.client.OpenShiftException;
+import com.openshift.client.cartridge.ICartridge;
 import com.openshift.client.cartridge.IStandaloneCartridge;
+import com.openshift.internal.client.httpclient.JsonMediaType;
 import com.openshift.internal.client.response.ApplicationResourceDTO;
 import com.openshift.internal.client.response.DomainResourceDTO;
 import com.openshift.internal.client.response.Link;
@@ -43,6 +47,7 @@ public class DomainResource extends AbstractOpenShiftResource implements IDomain
 	private static final String LINK_ADD_APPLICATION = "ADD_APPLICATION";
 	private static final String LINK_UPDATE = "UPDATE";
 	private static final String LINK_DELETE = "DELETE";
+    private static final String URL_REGEX="(https?|ftp)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]";
 	private String id;
 	private String suffix;
 	/** root node in the business domain. */
@@ -317,16 +322,26 @@ public class DomainResource extends AbstractOpenShiftResource implements IDomain
 			addScaleParameter(scale, parameters);
 			addGearProfileParameter(gearProfile, parameters);
 			addStringParameter(IOpenShiftJsonConstants.PROPERTY_INITIAL_GIT_URL, initialGitUrl, parameters);
-			
-			return super.execute(timeout, (ServiceParameter[]) parameters.toArray(new ServiceParameter[parameters.size()]));
+
+			if (isDownloadableCartridge(cartridge)) {
+                return super.execute(timeout, new JsonMediaType(), (ServiceParameter[]) parameters.toArray(new ServiceParameter[parameters.size()]));
+            } else {
+                return super.execute(timeout, (ServiceParameter[]) parameters.toArray(new ServiceParameter[parameters.size()]));
+            }
 		}
 
 		private List<ServiceParameter> addCartridgeParameter(IStandaloneCartridge cartridge, List<ServiceParameter> parameters) {
 			if (cartridge == null) {
 				return parameters;
 			}
-			parameters.add(new ServiceParameter(IOpenShiftJsonConstants.PROPERTY_CARTRIDGE, cartridge.getName()));
-			return parameters;
+            if (isDownloadableCartridge(cartridge)) {
+                Map<String,String> props = new HashMap<String, String>();
+                props.put(IOpenShiftJsonConstants.PROPERTY_URL, cartridge.getName());
+                parameters.add(new ServiceParameter(IOpenShiftJsonConstants.PROPERTY_CARTRIDGES, Arrays.asList(props)));
+            } else {
+                parameters.add(new ServiceParameter(IOpenShiftJsonConstants.PROPERTY_CARTRIDGE, cartridge.getName()));
+            }
+            return parameters;
 		}
 		
 		private List<ServiceParameter> addScaleParameter(ApplicationScale scale, List<ServiceParameter> parameters) {
@@ -352,6 +367,10 @@ public class DomainResource extends AbstractOpenShiftResource implements IDomain
 			parameters.add(new ServiceParameter(parameterName, value));
 			return parameters;
 		}
+
+        private boolean isDownloadableCartridge(ICartridge cartridge) {
+            return cartridge.getName().matches(URL_REGEX);
+        }
 
 	}
 

--- a/src/main/java/com/openshift/internal/client/IRestService.java
+++ b/src/main/java/com/openshift/internal/client/IRestService.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 import com.openshift.client.HttpMethod;
 import com.openshift.client.OpenShiftException;
+import com.openshift.internal.client.httpclient.IMediaType;
 import com.openshift.internal.client.response.Link;
 import com.openshift.internal.client.response.RestResponse;
 
@@ -34,17 +35,26 @@ public interface IRestService {
 	public RestResponse request(Link link, int timeout, ServiceParameter... serviceParameters)
 			throws OpenShiftException;
 
+    public RestResponse request(Link link, int timeout, IMediaType mediaType, ServiceParameter... serviceParameters)
+            throws OpenShiftException;
+
 	public abstract RestResponse request(Link link, Map<String, Object> parameters)
 			throws OpenShiftException;
 
 	public abstract RestResponse request(Link link, int timeout, Map<String, Object> parameters)
 			throws OpenShiftException;
 
+    public abstract RestResponse request(Link link, int timeout, IMediaType mediaType, Map<String, Object> parameters)
+            throws OpenShiftException;
+
 	public abstract String request(String url, HttpMethod httpMethod, Map<String, Object> parameters)
 			throws OpenShiftException;
 
 	public abstract String request(String url, HttpMethod httpMethod, int timeout, Map<String, Object> parameters)
 			throws OpenShiftException;
+
+    public abstract String request(String url, HttpMethod httpMethod, int timeout, IMediaType mediaType, Map<String, Object> parameters)
+            throws OpenShiftException;
 
 	public abstract String getServiceUrl();
 

--- a/src/main/java/com/openshift/internal/client/RestService.java
+++ b/src/main/java/com/openshift/internal/client/RestService.java
@@ -17,6 +17,8 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.openshift.internal.client.httpclient.EncodingException;
+import com.openshift.internal.client.httpclient.IMediaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,7 +95,12 @@ public class RestService implements IRestService {
 		return request(link, timeout, toMap(serviceParameters));
 	}
 
-	private Map<String, Object> toMap(ServiceParameter... serviceParameters) {
+    @Override
+    public RestResponse request(Link link, int timeout, IMediaType mediaType, ServiceParameter... serviceParameters) throws OpenShiftException {
+        return request(link, timeout, mediaType, toMap(serviceParameters));
+    }
+
+    private Map<String, Object> toMap(ServiceParameter... serviceParameters) {
 		Map<String, Object> parameterMap = new HashMap<String, Object>();
 		for (ServiceParameter serviceParameter : serviceParameters) {
 			parameterMap.put(serviceParameter.getKey(), serviceParameter.getValue());
@@ -106,37 +113,47 @@ public class RestService implements IRestService {
 	}
 	
 	public RestResponse request(Link link, int timeout, Map<String, Object> parameters) throws OpenShiftException {
-		validateParameters(parameters, link);
-		HttpMethod httpMethod = link.getHttpMethod();
-		String response = request(link.getHref(), httpMethod, timeout, parameters);
-		return ResourceDTOFactory.get(response);
+		return request(link, timeout, client.getRequestMediaType(), parameters);
 	}
 
-	public String request(String href, HttpMethod httpMethod, Map<String, Object> parameters) throws OpenShiftException {
+    @Override
+    public RestResponse request(Link link, int timeout, IMediaType mediaType, Map<String, Object> parameters) throws OpenShiftException {
+        validateParameters(parameters, link);
+        HttpMethod httpMethod = link.getHttpMethod();
+        String response = request(link.getHref(), httpMethod, timeout, mediaType, parameters);
+        return ResourceDTOFactory.get(response);
+    }
+
+    public String request(String href, HttpMethod httpMethod, Map<String, Object> parameters) throws OpenShiftException {
 		return request(href, httpMethod, IHttpClient.NO_TIMEOUT, parameters);
 	}
-	
+
 	public String request(String href, HttpMethod httpMethod, int timeout, Map<String, Object> parameters) throws OpenShiftException {
-		URL url = getUrl(href);
-		try {
-			return request(url, httpMethod, timeout, parameters);
-		} catch (UnsupportedEncodingException e) {
-			throw new OpenShiftException(e, e.getMessage());
-		} catch (UnauthorizedException e) {
-			throw new InvalidCredentialsOpenShiftException(url.toString(), e);
-		} catch (NotFoundException e) {
-			throw new NotFoundOpenShiftException(url.toString(), e);
-		} catch (HttpClientException e) {
-			throw new OpenShiftEndpointException(
-					url.toString(), e, e.getMessage(),
-					"Could not request {0}: {1}", url.toString(), getResponseMessage(e));
-		} catch (SocketTimeoutException e) {
-			throw new OpenShiftTimeoutException(url.toString(), e, e.getMessage(),
-					"Could not request url {0}, connection timed out", url.toString());
-		}
+		return request(href, httpMethod, timeout, client.getRequestMediaType(), parameters);
 	}
 
-	private String getResponseMessage(HttpClientException clientException) {
+    @Override
+    public String request(String href, HttpMethod httpMethod, int timeout, IMediaType mediaType, Map<String, Object> parameters) throws OpenShiftException {
+        URL url = getUrl(href);
+        try {
+            return request(url, httpMethod, timeout, mediaType, parameters);
+        } catch (EncodingException e) {
+            throw new OpenShiftException(e, e.getMessage());
+        } catch (UnauthorizedException e) {
+            throw new InvalidCredentialsOpenShiftException(url.toString(), e);
+        } catch (NotFoundException e) {
+            throw new NotFoundOpenShiftException(url.toString(), e);
+        } catch (HttpClientException e) {
+            throw new OpenShiftEndpointException(
+                    url.toString(), e, e.getMessage(),
+                    "Could not request {0}: {1}", url.toString(), getResponseMessage(e));
+        } catch (SocketTimeoutException e) {
+            throw new OpenShiftTimeoutException(url.toString(), e, e.getMessage(),
+                    "Could not request url {0}, connection timed out", url.toString());
+        }
+    }
+
+    private String getResponseMessage(HttpClientException clientException) {
 		try {
 			RestResponse restResponse = ResourceDTOFactory.get(clientException.getMessage());
 			if (restResponse == null) {
@@ -157,8 +174,8 @@ public class RestService implements IRestService {
 		}
 	}
 
-	private String request(URL url, HttpMethod httpMethod, int timeout, Map<String, Object> parameters)
-			throws HttpClientException, SocketTimeoutException, OpenShiftException, UnsupportedEncodingException {
+	private String request(URL url, HttpMethod httpMethod, int timeout, IMediaType mediaType, Map<String, Object> parameters)
+			throws HttpClientException, SocketTimeoutException, OpenShiftException, EncodingException {
 		LOGGER.info("Requesting {} with protocol {} on {}",
 				new Object[] { httpMethod.name(), client.getAcceptVersion(), url });
 		
@@ -166,11 +183,11 @@ public class RestService implements IRestService {
 		case GET:
 			return client.get(url, timeout);
 		case POST:
-			return client.post(parameters, url, timeout);
+			return client.post(parameters, url, timeout, mediaType);
 		case PUT:
-			return client.put(parameters, url, timeout);
+			return client.put(parameters, url, timeout, mediaType);
 		case DELETE:
-			return client.delete(parameters, url, timeout);
+			return client.delete(parameters, url, timeout, mediaType);
 		default:
 			throw new OpenShiftException("Unexpected HTTP method {0}", httpMethod.toString());
 		}

--- a/src/main/java/com/openshift/internal/client/httpclient/EncodingException.java
+++ b/src/main/java/com/openshift/internal/client/httpclient/EncodingException.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2011 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.internal.client.httpclient;
+
+import java.io.IOException;
+
+/**
+ * @author Ioannis Canellos
+ */
+public class EncodingException extends IOException {
+
+    public EncodingException() {
+    }
+
+    public EncodingException(String message) {
+        super(message);
+    }
+
+    public EncodingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public EncodingException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/openshift/internal/client/httpclient/FormUrlEncodedMediaType.java
+++ b/src/main/java/com/openshift/internal/client/httpclient/FormUrlEncodedMediaType.java
@@ -28,9 +28,13 @@ public class FormUrlEncodedMediaType implements IMediaType {
 		return IHttpClient.MEDIATYPE_APPLICATION_FORMURLENCODED;
 	}
 
-	public String encodeParameters(Map<String, Object> parameters) throws UnsupportedEncodingException {
-		return toUrlEncoded(parameters);
-	}
+	public String encodeParameters(Map<String, Object> parameters) throws EncodingException {
+        try {
+            return toUrlEncoded(parameters);
+        } catch (UnsupportedEncodingException e) {
+            throw new EncodingException(e);
+        }
+    }
 
 	private String toUrlEncoded(Map<String, Object> parameters) throws UnsupportedEncodingException {
 		if (parameters == null

--- a/src/main/java/com/openshift/internal/client/httpclient/IMediaType.java
+++ b/src/main/java/com/openshift/internal/client/httpclient/IMediaType.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package com.openshift.internal.client.httpclient;
 
-import java.io.UnsupportedEncodingException;
 import java.util.Map;
 
 /**
@@ -20,6 +19,6 @@ public interface IMediaType {
 
 	public String getType();
 	
-	public String encodeParameters(Map<String, Object> parameters) throws UnsupportedEncodingException;
+	public String encodeParameters(Map<String, Object> parameters) throws EncodingException;
 	
 }

--- a/src/main/java/com/openshift/internal/client/httpclient/JsonMediaType.java
+++ b/src/main/java/com/openshift/internal/client/httpclient/JsonMediaType.java
@@ -1,0 +1,39 @@
+/******************************************************************************* 
+ * Copyright (c) 2012 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ *
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package com.openshift.internal.client.httpclient;
+
+import com.openshift.client.IHttpClient;
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * @author Ioannis Canellos
+ */
+public class JsonMediaType implements IMediaType {
+
+    private static final JsonFactory JSON_FACTORY = new JsonFactory();
+    private static final ObjectMapper MAPPER = new ObjectMapper(JSON_FACTORY);
+
+    public String getType() {
+        return IHttpClient.MEDIATYPE_APPLICATION_JSON;
+    }
+
+    public String encodeParameters(Map<String, Object> parameters) throws EncodingException {
+        try {
+            return MAPPER.writeValueAsString(parameters);
+        } catch (IOException e) {
+            throw new EncodingException(e);
+        }
+    }
+}

--- a/src/main/java/com/openshift/internal/client/httpclient/UrlConnectionHttpClient.java
+++ b/src/main/java/com/openshift/internal/client/httpclient/UrlConnectionHttpClient.java
@@ -112,7 +112,7 @@ public class UrlConnectionHttpClient implements IHttpClient {
 
 		HttpURLConnection connection = null;
 		try {
-			return write(null, HttpMethod.GET.toString(), url, timeout);
+			return write(null, HttpMethod.GET.toString(), url, timeout, requestMediaType);
 		} catch (SocketTimeoutException e) {
 			throw e;
 		/* TODO: cleanup exception handling */
@@ -139,61 +139,84 @@ public class UrlConnectionHttpClient implements IHttpClient {
 		return acceptVersion;
 	}
 
-	public String put(Map<String, Object> parameters, URL url)
-			throws SocketTimeoutException, UnsupportedEncodingException, HttpClientException {
+    public IMediaType getRequestMediaType() {
+        return requestMediaType;
+    }
+
+    public void setRequestMediaType(IMediaType requestMediaType) {
+        this.requestMediaType = requestMediaType;
+    }
+
+    public String put(Map<String, Object> parameters, URL url)
+			throws SocketTimeoutException, EncodingException, HttpClientException {
 		return put(requestMediaType.encodeParameters(parameters), url);
 	}
 
 	@Override
 	public String put(Map<String, Object> parameters, URL url, int timeout) 
-			throws HttpClientException, SocketTimeoutException, UnsupportedEncodingException {
-		return write(requestMediaType.encodeParameters(parameters), HttpMethod.PUT.toString(), url, timeout);
+			throws HttpClientException, SocketTimeoutException, EncodingException {
+		return put(parameters, url, timeout, requestMediaType);
 	}
 
-	protected String put(String data, URL url) throws HttpClientException, SocketTimeoutException {
-		return write(data, HttpMethod.PUT.toString(), url, NO_TIMEOUT);
+    @Override
+    public String put(Map<String, Object> parameters, URL url, int timeout, IMediaType mediaType) throws HttpClientException, SocketTimeoutException, EncodingException {
+        return write(mediaType.encodeParameters(parameters), HttpMethod.PUT.toString(), url, timeout, mediaType);
+    }
+
+    protected String put(String data, URL url) throws HttpClientException, SocketTimeoutException {
+		return write(data, HttpMethod.PUT.toString(), url, NO_TIMEOUT, requestMediaType);
 	}
 
 	public String post(Map<String, Object> parameters, URL url)
-			throws SocketTimeoutException, UnsupportedEncodingException, HttpClientException {
+			throws SocketTimeoutException, EncodingException, HttpClientException {
 		return post(requestMediaType.encodeParameters(parameters), url);
 	}
 
 	protected String post(String data, URL url) throws HttpClientException, SocketTimeoutException {
-		return write(data, HttpMethod.POST.toString(), url, NO_TIMEOUT);
+		return write(data, HttpMethod.POST.toString(), url, NO_TIMEOUT, requestMediaType);
 	}
 
 	public String post(Map<String, Object> data, URL url, int timeout) 
-			throws HttpClientException, SocketTimeoutException, UnsupportedEncodingException {
-		return write(requestMediaType.encodeParameters(data), HttpMethod.POST.toString(), url, timeout);
+			throws HttpClientException, SocketTimeoutException, EncodingException {
+        return post(data, url, timeout, requestMediaType);
 	}
 
-	public String delete(Map<String, Object> parameters, URL url)
-			throws HttpClientException, SocketTimeoutException, UnsupportedEncodingException {
+    @Override
+    public String post(Map<String, Object> parameters, URL url, int timeout, IMediaType mediaType) throws HttpClientException, SocketTimeoutException, EncodingException {
+        return write(mediaType.encodeParameters(parameters), HttpMethod.POST.toString(), url, timeout, mediaType);
+    }
+
+    public String delete(Map<String, Object> parameters, URL url)
+			throws HttpClientException, SocketTimeoutException, EncodingException {
 		return delete(requestMediaType.encodeParameters(parameters), url);
 	}
 
 	@Override
 	public String delete(Map<String, Object> parameters, URL url, int timeout) throws HttpClientException,
 			SocketTimeoutException,
-			UnsupportedEncodingException {
-		return write(requestMediaType.encodeParameters(parameters), HttpMethod.DELETE.toString(), url, timeout);
+            EncodingException {
+		return delete(parameters, url, timeout, requestMediaType);
 	}
 
-	public String delete(URL url)
+    @Override
+    public String delete(Map<String, Object> parameters, URL url, int timeout, IMediaType mediaType) throws HttpClientException, SocketTimeoutException, EncodingException {
+        return write(mediaType.encodeParameters(parameters), HttpMethod.DELETE.toString(), url, timeout, mediaType);
+    }
+
+    public String delete(URL url)
 			throws HttpClientException, SocketTimeoutException, UnsupportedEncodingException {
 		return delete((String) null, url);
 	}
 
 	protected String delete(String data, URL url) throws HttpClientException, SocketTimeoutException {
-		return write(data, HttpMethod.DELETE.toString(), url, NO_TIMEOUT);
+		return write(data, HttpMethod.DELETE.toString(), url, NO_TIMEOUT, requestMediaType);
 	}
 
-	protected String write(String data, String requestMethod, URL url, int timeout)
+	protected String write(String data, String requestMethod, URL url, int timeout, IMediaType mediaType)
 			throws SocketTimeoutException, HttpClientException {
 		HttpURLConnection connection = null;
 		try {
-			connection = createConnection(username, password, authKey, authIV, userAgent, url, timeout);
+			connection = createConnection(username, password, authKey, authIV, userAgent, url, timeout, mediaType);
 			connection.setRequestMethod(requestMethod);
 			connection.setDoOutput(true);
 			if (data != null) {
@@ -281,11 +304,11 @@ public class UrlConnectionHttpClient implements IHttpClient {
 
 	protected HttpURLConnection createConnection(String username, String password, String userAgent, URL url)
 			throws IOException {
-		return createConnection(username, password, null, null, userAgent, url, NO_TIMEOUT);
+		return createConnection(username, password, null, null, userAgent, url, NO_TIMEOUT, requestMediaType);
 	}
 
 	protected HttpURLConnection createConnection(String username, String password, String authKey, String authIV,
-			String userAgent, URL url, int timeout) throws IOException {
+			String userAgent, URL url, int timeout, IMediaType mediaType) throws IOException {
 		LOGGER.trace(
 				"creating connection to {} using username \"{}\" and password \"{}\"", new Object[] { url, username,
 						password });
@@ -303,7 +326,7 @@ public class UrlConnectionHttpClient implements IHttpClient {
 		setAcceptHeader(connection);
 		setUserAgent(connection);
 
-		connection.setRequestProperty(PROPERTY_CONTENT_TYPE, requestMediaType.getType());
+		connection.setRequestProperty(PROPERTY_CONTENT_TYPE, mediaType.getType());
 
 		return connection;
 	}

--- a/src/main/java/com/openshift/internal/client/utils/IOpenShiftJsonConstants.java
+++ b/src/main/java/com/openshift/internal/client/utils/IOpenShiftJsonConstants.java
@@ -23,6 +23,7 @@ public class IOpenShiftJsonConstants {
 	public static final String PROPERTY_APP_NAME = "app_name";
 	public static final String PROPERTY_CREATION_TIME = "creation_time";
 	public static final String PROPERTY_CARTRIDGE = "cartridge";
+    public static final String PROPERTY_CARTRIDGES = "cartridges";
 	public static final String PROPERTY_CONSUMED_GEARS = "consumed_gears";
 	public static final String PROPERTY_CONTENT = "content";
 	public static final String PROPERTY_DATA = "data";
@@ -83,7 +84,9 @@ public class IOpenShiftJsonConstants {
 	public static final String PROPERTY_VALID_OPTIONS = "valid_options";
 	public static final String PROPERTY_APP_URL = "app_url";
 	public static final String PROPERTY_GIT_URL = "git_url";
-	
+
+    public static final String PROPERTY_URL = "url";
+
 	public static final String VALUE_STATUS_OK = "ok";
 	public static final String VALUE_STATUS_CREATED = "created";
 	public static final Object VALUE_ADD_ALIAS = "add-alias";

--- a/src/test/java/com/openshift/client/fakes/HttpClientFake.java
+++ b/src/test/java/com/openshift/client/fakes/HttpClientFake.java
@@ -19,6 +19,7 @@ import com.openshift.client.OpenShiftException;
 import com.openshift.client.utils.OpenShiftTestConfiguration;
 import com.openshift.internal.client.httpclient.FormUrlEncodedMediaType;
 import com.openshift.internal.client.httpclient.HttpClientException;
+import com.openshift.internal.client.httpclient.IMediaType;
 import com.openshift.internal.client.httpclient.UrlConnectionHttpClient;
 
 /**
@@ -32,7 +33,7 @@ public class HttpClientFake extends UrlConnectionHttpClient {
 	}
 	
 	@Override
-	protected String write(String data, String requestMethod, URL url, int timeout)
+	protected String write(String data, String requestMethod, URL url, int timeout, IMediaType mediaType)
 			throws SocketTimeoutException, HttpClientException {
 		return data;
 	}

--- a/src/test/java/com/openshift/internal/client/HttpClientMockDirector.java
+++ b/src/test/java/com/openshift/internal/client/HttpClientMockDirector.java
@@ -26,6 +26,8 @@ import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.util.Map;
 
+import com.openshift.internal.client.httpclient.EncodingException;
+import com.openshift.internal.client.httpclient.IMediaType;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -52,6 +54,11 @@ public class HttpClientMockDirector {
 		return this;
 	}
 
+    public HttpClientMockDirector mockMediaType(IMediaType mediaType) throws SocketTimeoutException, HttpClientException {
+        when(client.getRequestMediaType()).thenReturn(mediaType);
+        return this;
+    }
+
 	public HttpClientMockDirector mockGetAny(String response) throws SocketTimeoutException, HttpClientException {
 		when(client.get(any(URL.class), anyInt())).thenReturn(response);
 		return this;
@@ -63,34 +70,34 @@ public class HttpClientMockDirector {
 	}
 
 	public HttpClientMockDirector mockPostAny(Samples postRequestResponse)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		return mockPostAny(postRequestResponse.getContentAsString());
 	}
 
 	public HttpClientMockDirector mockPostAny(String jsonResponse)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
-		when(client.post(anyMapOf(String.class, Object.class), any(URL.class), anyInt()))
+			throws SocketTimeoutException, HttpClientException, EncodingException {
+		when(client.post(anyMapOf(String.class, Object.class), any(URL.class), anyInt(), any(IMediaType.class)))
 				.thenReturn(jsonResponse);
 		return this;
 	}
 
 	public HttpClientMockDirector mockPostAny(Exception exception)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
-		when(client.post(anyMapOf(String.class, Object.class), any(URL.class), anyInt()))
+			throws SocketTimeoutException, HttpClientException, EncodingException {
+		when(client.post(anyMapOf(String.class, Object.class), any(URL.class), anyInt(), any(IMediaType.class)))
 				.thenThrow(exception);
 		return this;
 	}
 
 	public HttpClientMockDirector mockPutAny(String jsonResponse)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		when(client.put(anyMapOf(String.class, Object.class), any(URL.class)))
 				.thenReturn(jsonResponse);
 		return this;
 	}
 
 	public HttpClientMockDirector mockDeleteAny(String jsonResponse)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
-		when(client.delete(anyMapOf(String.class, Object.class), any(URL.class), anyInt()))
+			throws SocketTimeoutException, HttpClientException, EncodingException {
+		when(client.delete(anyMapOf(String.class, Object.class), any(URL.class), anyInt(), any(IMediaType.class)))
 				.thenReturn(jsonResponse);
 		return this;
 	}
@@ -129,21 +136,23 @@ public class HttpClientMockDirector {
 	}
 	
 	public HttpClientMockDirector mockCreateKey(Samples createKeyRequestResponse) 
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		when(client.post(
 				anyMapOf(String.class, Object.class), 
 				urlEndsWith("/user/keys"),
-				anyInt()))
+				anyInt(),
+                any(IMediaType.class)))
 				.thenReturn(createKeyRequestResponse.getContentAsString());
 		return this;
 	}
 
 	public HttpClientMockDirector mockUpdateKey(String keyName, Samples updateKeyRequestResponse, Pair... pairs) 
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		when(client.put(
 				anyMapOf(String.class, Object.class), 
 				urlEndsWith("/user/keys/" + keyName),
-				anyInt()))
+				anyInt(),
+                any(IMediaType.class)))
 				.thenReturn(updateKeyRequestResponse.getContentAsString());
 		return this;
 	}
@@ -156,29 +165,29 @@ public class HttpClientMockDirector {
 	}
 
 	public HttpClientMockDirector mockCreateDomain(Samples domainResourceResponse)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
-		when(client.post(anyMapOf(String.class, Object.class), urlEndsWith("/domains"), anyInt()))
+			throws SocketTimeoutException, HttpClientException, EncodingException {
+		when(client.post(anyMapOf(String.class, Object.class), urlEndsWith("/domains"), anyInt(), any(IMediaType.class)))
 				.thenReturn(domainResourceResponse.getContentAsString());
 		return this;
 	}
 
 	public HttpClientMockDirector mockDeleteDomain(String domainId, Samples deleteDomainResourceResponse)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
-		when(client.delete(anyMapOf(String.class, Object.class), urlEndsWith("/domains/" + domainId), anyInt()))
+			throws SocketTimeoutException, HttpClientException, EncodingException {
+		when(client.delete(anyMapOf(String.class, Object.class), urlEndsWith("/domains/" + domainId), anyInt(), any(IMediaType.class)))
 				.thenReturn(deleteDomainResourceResponse.getContentAsString());
 		return this;
 	}
 
 	public HttpClientMockDirector mockDeleteDomain(String domainId, Exception exception)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
-		when(client.delete(anyMapOf(String.class, Object.class), urlEndsWith("/domains/" + domainId), anyInt()))
+			throws SocketTimeoutException, HttpClientException, EncodingException {
+		when(client.delete(anyMapOf(String.class, Object.class), urlEndsWith("/domains/" + domainId), anyInt(), any(IMediaType.class)))
 				.thenThrow(exception);
 		return this;
 	}
 
 	public HttpClientMockDirector mockRenameDomain(String domainId, Samples getDomainsResourceResponse)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
-		when(client.put(anyMapOf(String.class, Object.class), urlEndsWith("/domains/" + domainId), anyInt()))
+			throws SocketTimeoutException, HttpClientException, EncodingException {
+		when(client.put(anyMapOf(String.class, Object.class), urlEndsWith("/domains/" + domainId), anyInt(), any(IMediaType.class)))
 				.thenReturn(getDomainsResourceResponse.getContentAsString());
 		return this;
 	}
@@ -199,20 +208,21 @@ public class HttpClientMockDirector {
 	}
 
 	public HttpClientMockDirector mockCreateApplication(String domainId, Samples postDomainsResourceResponse)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		when(client.post(anyMapOf(String.class, Object.class),
-				urlEndsWith("/domains/" + domainId + "/applications"), anyInt()))
+				urlEndsWith("/domains/" + domainId + "/applications"), anyInt(), any(IMediaType.class)))
 				.thenReturn(postDomainsResourceResponse.getContentAsString());
 		return this;
 	}
 
 	public HttpClientMockDirector mockPostApplicationEvent(String domainId, String applicationName,
 			Samples postApplicationEvent)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		when(client.post(
 				anyMapOf(String.class, Object.class),
 				urlEndsWith("/domains/" + domainId + "/applications/" + applicationName + "/events"),
-				anyInt()))
+				anyInt(),
+                any(IMediaType.class)))
 				.thenReturn(postApplicationEvent.getContentAsString());
 		return this;
 	}
@@ -236,11 +246,12 @@ public class HttpClientMockDirector {
 	}
 
 	public HttpClientMockDirector mockPostApplicationEvent(String domainId, String applicationName, Exception exception)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		when(client.post(
 				anyMapOf(String.class, Object.class),
 				urlEndsWith("/domains/" + domainId + "/applications/" + applicationName + "/events"),
-				anyInt()))
+				anyInt(),
+                any(IMediaType.class)))
 				.thenThrow(exception);
 		return this;
 	}
@@ -257,22 +268,24 @@ public class HttpClientMockDirector {
 
 	public HttpClientMockDirector mockAddEmbeddableCartridge(String domainId, String applicationName,
 			Samples addEmbeddedCartridgeResponse)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		when(client.post(
 				anyMapOf(String.class, Object.class),
 				urlEndsWith("/domains/" + domainId + "/applications/" + applicationName + "/cartridges"),
-				anyInt()))
+				anyInt(),
+                any(IMediaType.class)))
 				.thenReturn(addEmbeddedCartridgeResponse.getContentAsString());
 		return this;
 	}
 
 	public HttpClientMockDirector mockAddEmbeddableCartridge(String domainId, String applicationName,
 			Exception exception)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		when(client.post(
 				anyMapOf(String.class, Object.class),
 				urlEndsWith("/domains/" + domainId + "/applications/" + applicationName + "/cartridges"),
-				anyInt()))
+				anyInt(),
+                any(IMediaType.class)))
 				.thenThrow(exception);
 		return this;
 	}
@@ -280,22 +293,24 @@ public class HttpClientMockDirector {
 	public HttpClientMockDirector mockRemoveEmbeddableCartridge(String domainId, String applicationName,
 			String cartridgeName,
 			Exception exception)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		when(client.delete(
 				anyMapOf(String.class, Object.class),
 				urlEndsWith(
 				"/domains/" + domainId + "/applications/" + applicationName + "/cartridges/" + cartridgeName),
-				anyInt()))
+				anyInt(),
+                any(IMediaType.class)))
 				.thenThrow(exception);
 		return this;
 	}
 
 	public HttpClientMockDirector verifyPostApplicationEvent(String domainId, String applicationName)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		verify(client, times(1)).post(
 				anyMapOf(String.class, Object.class),
 				urlEndsWith("/domains/" + domainId + "/applications/" + applicationName + "/events"),
-				anyInt());
+				anyInt(),
+                any(IMediaType.class));
 		return this;
 	}
 
@@ -317,22 +332,24 @@ public class HttpClientMockDirector {
 	}
 
 	public HttpClientMockDirector verifyAddEmbeddableCartridge(String domainId, String applicationName)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		verify(client, times(1)).post(
 				anyMapOf(String.class, Object.class),
 				urlEndsWith("/domains/" + domainId + "/applications/" + applicationName + "/cartridges"),
-				anyInt());
+				anyInt(),
+                any(IMediaType.class));
 		return this;
 	}
 
 	public HttpClientMockDirector verifyDeleteEmbeddableCartridge(String domainId, String applicationName,
 			String cartridgeName)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		verify(client, times(1)).delete(
 				anyMapOf(String.class, Object.class),
 				urlEndsWith("/domains/" + domainId + "/applications/" + applicationName + "/cartridges/"
 						+ cartridgeName),
-				anyInt());
+				anyInt(),
+                any(IMediaType.class));
 		return this;
 	}
 
@@ -348,38 +365,38 @@ public class HttpClientMockDirector {
 	}
 
 	public HttpClientMockDirector verifyPostAny(int times)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
-		verify(client, times(times)).post(anyMapOf(String.class, Object.class), any(URL.class), anyInt());
+			throws SocketTimeoutException, HttpClientException, EncodingException {
+		verify(client, times(times)).post(anyMapOf(String.class, Object.class), any(URL.class), anyInt(), any(IMediaType.class));
 		return this;
 	}
 
 	public HttpClientMockDirector verifyPost(String url, int times)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException, MalformedURLException {
-		verify(client, times(times)).post(anyMapOf(String.class, Object.class), new URL(url), anyInt());
+			throws SocketTimeoutException, HttpClientException, EncodingException, MalformedURLException {
+		verify(client, times(times)).post(anyMapOf(String.class, Object.class), new URL(url), anyInt(), any(IMediaType.class));
 		return this;
 	}
 
 	public HttpClientMockDirector verifyPutAny(int times)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
-		verify(client, times(times)).put(anyMapOf(String.class, Object.class), any(URL.class), anyInt());
+			throws SocketTimeoutException, HttpClientException, EncodingException {
+		verify(client, times(times)).put(anyMapOf(String.class, Object.class), any(URL.class), anyInt(), any(IMediaType.class));
 		return this;
 	}
 
 	public HttpClientMockDirector verifyPut(String url, int times)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException, MalformedURLException {
-		verify(client, times(times)).put(anyMapOf(String.class, Object.class), new URL(url), anyInt());
+			throws SocketTimeoutException, HttpClientException, EncodingException, MalformedURLException {
+		verify(client, times(times)).put(anyMapOf(String.class, Object.class), new URL(url), anyInt(), any(IMediaType.class));
 		return this;
 	}
 
 	public HttpClientMockDirector verifyDeleteAny(int times)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
-		verify(client, times(times)).delete(anyMapOf(String.class, Object.class), any(URL.class), anyInt());
+			throws SocketTimeoutException, HttpClientException, EncodingException {
+		verify(client, times(times)).delete(anyMapOf(String.class, Object.class), any(URL.class), anyInt(), any(IMediaType.class));
 		return this;
 	}
 
 	public HttpClientMockDirector verifyDelete(String url, int times)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException, MalformedURLException {
-		verify(client, times(times)).delete(anyMapOf(String.class, Object.class), new URL(url), anyInt());
+			throws SocketTimeoutException, HttpClientException, EncodingException, MalformedURLException {
+		verify(client, times(times)).delete(anyMapOf(String.class, Object.class), new URL(url), anyInt(), any(IMediaType.class));
 		return this;
 	}
 
@@ -389,8 +406,8 @@ public class HttpClientMockDirector {
 	}
 
 	public HttpClientMockDirector verifyRenameDomain(String domainId)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
-		verify(client, times(1)).put(anyMapOf(String.class, Object.class), urlEndsWith(domainId), anyInt());
+			throws SocketTimeoutException, HttpClientException, EncodingException {
+		verify(client, times(1)).put(anyMapOf(String.class, Object.class), urlEndsWith(domainId), anyInt(), any(IMediaType.class));
 		return this;
 	}
 
@@ -416,43 +433,51 @@ public class HttpClientMockDirector {
 	}
 
 	public HttpClientMockDirector verifyCreateKey(Pair... pairs)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		verify(client).post(anyMapOf(String.class, Object.class),
-				urlEndsWith("/user/keys"), eq(IHttpClient.NO_TIMEOUT));
+				urlEndsWith("/user/keys"), eq(IHttpClient.NO_TIMEOUT), any(IMediaType.class));
 		assertPostParameters(pairs);
 		return this;
 	}
 
 	public HttpClientMockDirector verifyUpdateKey(String keyName, Pair... pairs)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		verify(client).put(anyMapOf(String.class, Object.class),
-				urlEndsWith("/user/keys/" + keyName), eq(IHttpClient.NO_TIMEOUT));
+				urlEndsWith("/user/keys/" + keyName), eq(IHttpClient.NO_TIMEOUT), any(IMediaType.class));
 		assertPutParameters(pairs);
 		return this;
 	}
 
 	public HttpClientMockDirector verifyCreateApplication(String domainId, int timeout, Pair... pairs)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		verify(client).post(anyMapOf(String.class, Object.class),
-				urlEndsWith("/domains/" + domainId + "/applications"), eq(timeout));
+				urlEndsWith("/domains/" + domainId + "/applications"), eq(timeout), any(IMediaType.class));
 		assertPostParameters(pairs);
 		return this;
 	}
 
+    public HttpClientMockDirector verifyCreateApplication(String domainId, int timeout, Class<? extends IMediaType> mediaType, Pair... pairs)
+            throws SocketTimeoutException, HttpClientException, EncodingException {
+        verify(client).post(anyMapOf(String.class, Object.class),
+                urlEndsWith("/domains/" + domainId + "/applications"), eq(timeout), any(mediaType));
+        assertPostParameters(pairs);
+        return this;
+    }
+
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public HttpClientMockDirector assertPostParameters(Pair... pairs)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
-		verify(client).post(captor.capture(), any(URL.class), anyInt());
+		verify(client).post(captor.capture(), any(URL.class), anyInt(), any(IMediaType.class));
 		assertParameters(captor.getValue(), pairs);
 		return this;
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public HttpClientMockDirector assertPutParameters(Pair... pairs)
-			throws SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws SocketTimeoutException, HttpClientException, EncodingException {
 		ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
-		verify(client).put(captor.capture(), any(URL.class), anyInt());
+		verify(client).put(captor.capture(), any(URL.class), anyInt(), any(IMediaType.class));
 		assertParameters(captor.getValue(), pairs);
 		return this;
 	}
@@ -460,8 +485,9 @@ public class HttpClientMockDirector {
 	private void assertParameters(@SuppressWarnings("rawtypes") Map postedParameters, Pair... pairs) {
 		assertThat(postedParameters).hasSize(pairs.length);
 		for (Pair pair : pairs) {
-			String value = (String) postedParameters.get(pair.getKey());
-			assertThat(value).isNotNull().isEqualTo(pair.getValue());
+			Object value = postedParameters.get(pair.getKey());
+            //It's possible that the value is not a String (e.g. a Map), so we convert to String before checking.
+			assertThat(value.toString()).isNotNull().isEqualTo(pair.getValue());
 		}
 	}
 

--- a/src/test/java/com/openshift/internal/client/HttpClientTest.java
+++ b/src/test/java/com/openshift/internal/client/HttpClientTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.fail;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.SocketTimeoutException;
@@ -30,6 +29,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.openshift.internal.client.httpclient.EncodingException;
+import com.openshift.internal.client.httpclient.IMediaType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -79,7 +80,7 @@ public class HttpClientTest {
 
 	@Test
 	public void canPost() throws SocketTimeoutException, HttpClientException, MalformedURLException,
-			UnsupportedEncodingException {
+            EncodingException {
 		String response = httpClient.post(new HashMap<String, Object>(), serverFake.getUrl());
 		assertNotNull(response);
 		assertTrue(response.startsWith("POST"));
@@ -87,7 +88,7 @@ public class HttpClientTest {
 
 	@Test
 	public void canPut() throws SocketTimeoutException, HttpClientException, MalformedURLException,
-			UnsupportedEncodingException {
+            EncodingException {
 		String response = httpClient.put(new HashMap<String, Object>(), serverFake.getUrl());
 		assertNotNull(response);
 		assertTrue(response.startsWith("PUT"));
@@ -95,7 +96,7 @@ public class HttpClientTest {
 
 	@Test
 	public void canDelete() throws SocketTimeoutException, HttpClientException, MalformedURLException,
-			UnsupportedEncodingException {
+            EncodingException {
 		String response = httpClient.delete(new HashMap<String, Object>(), serverFake.getUrl());
 		assertNotNull(response);
 		assertTrue(response.startsWith("DELETE"));
@@ -186,7 +187,7 @@ public class HttpClientTest {
 		IHttpClient httpClient = new HttpClientFake(IHttpClient.MEDIATYPE_APPLICATION_JSON, version) {
 
 			@Override
-			protected String write(String data, String requestMethod, URL url, int timeout)
+			protected String write(String data, String requestMethod, URL url, int timeout, IMediaType mediaType)
 					throws SocketTimeoutException, HttpClientException {
 				try {
 					HttpURLConnection connection = createConnection("dummyUser", "dummyPassword", "dummyUserAgent", url);

--- a/src/test/java/com/openshift/internal/client/RestServiceTest.java
+++ b/src/test/java/com/openshift/internal/client/RestServiceTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Properties;
 
+import com.openshift.internal.client.httpclient.EncodingException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -96,7 +97,7 @@ public class RestServiceTest {
 
 	@Test
 	public void shouldPostIfPostHttpMethod() throws OpenShiftException, SocketTimeoutException, HttpClientException,
-			UnsupportedEncodingException {
+            EncodingException {
 		// operation
 		service.request(new Link("0 required parameter", "http://www.redhat.com", HttpMethod.POST, null, null));
 		// verifications
@@ -105,7 +106,7 @@ public class RestServiceTest {
 
 	@Test
 	public void shouldPutIfPutHttpMethod() throws OpenShiftException, SocketTimeoutException, HttpClientException,
-			UnsupportedEncodingException {
+            EncodingException {
 		// operation
 		service.request(new Link("0 required parameter", "http://www.redhat.com", HttpMethod.PUT, null, null));
 		// verifications
@@ -114,7 +115,7 @@ public class RestServiceTest {
 
 	@Test
 	public void shouldDeleteIfDeleteHttpMethod() throws OpenShiftException, SocketTimeoutException,
-			HttpClientException, UnsupportedEncodingException {
+			HttpClientException, EncodingException {
 		// operation
 		service.request(new Link("0 required parameter", "http://www.redhat.com", HttpMethod.DELETE, null, null));
 		// verifications
@@ -249,7 +250,7 @@ public class RestServiceTest {
 
 	@Test
 	public void shouldDefaultTo12ProtocolVersion() 
-			throws OpenShiftException, SocketTimeoutException, HttpClientException, UnsupportedEncodingException {
+			throws OpenShiftException, SocketTimeoutException, HttpClientException, EncodingException {
 		// pre-condition
 		RestServiceProperties properties = new RestServiceProperties();
 		IHttpClient httpClientMock = mock(IHttpClient.class);


### PR DESCRIPTION
I am working on https://github.com/jboss-fuse/fuse/issues/52 and I it seems that the client is missing support for downloadable cartridges.

Given that there is no information in the rest api about this feature, I tried to mimic the behavior of rhc which already supports that. 

So this pull request does the following:

When the cartridge name is a URL, it posts a json like this:

{
    "name": "myapp",
    "cartridges": [{
        "url": "https://raw.github.com/myrepo/mycart/master/metadata/manifest.yml"
    }]
}

In detail this commit adds:

i) An implementation of IMediaType for Json
ii) Adds the ability to override the existing media type on the IHttpClient and IRestService
iii) DomainResource checks when creating an app if cart is downloadable and uses JsonMediaType instead (plus the appropriate ServiceParameters).
iv) Aligns tests and adds a test case for downloadable carts.
