### PR TITLE
[JBIDE-15766]:Remove refresh of all IEnvironmentVariable on add/remove actions

### DIFF
--- a/src/main/java/com/openshift/client/IApplication.java
+++ b/src/main/java/com/openshift/client/IApplication.java
@@ -26,6 +26,7 @@ import com.openshift.internal.client.ApplicationResource;
 /**
  * @author André Dietisheim
  * @author Syed Iqbal
+ * @author Martes G Wigglesworth
  */
 public interface IApplication extends IOpenShiftResource {
 
@@ -423,7 +424,7 @@ public interface IApplication extends IOpenShiftResource {
 	/**
 	 * Retrieves the map of environment variables
 	 * 
-	 * @return the list of environment variables
+	 * @return the Map<String,IEnvironmentVariable> of environment variables
 	 * @throws OpenShiftSSHOperationException
 	 */
 	public Map<String, IEnvironmentVariable> getEnvironmentVariables() throws OpenShiftSSHOperationException;
@@ -431,30 +432,26 @@ public interface IApplication extends IOpenShiftResource {
 	/**
 	 * Checks if the environment variable is present in the application.
 	 * 
-	 * @param name
-	 *            Name of the environment variable
-	 * @return
+	 * @param name  Name of the environment variable
+	 * @return <code>true</code> if the current instance has IEnvironmentVariables to return <br>
+	 *         <code>false</code> if the current instance has no IEnvironmentVariables to return
 	 * @throws OpenShiftSSHOperationException
 	 */
 	public boolean hasEnvironmentVariable(String name) throws OpenShiftException;
 
 	/**
-	 * Adds an environment variable to this application. If the environment
-	 * variable exists already, then an OpenShift exception is thrown.
+	 * Adds an environment variable to this application. 
 	 * 
-	 * @param name
-	 *            name of the variable to add
-	 * @param value
-	 *            value of the new variable
-	 * @throws OpenShiftSSHOperationException
+	 * @param name  key associated with the variable to add
+	 * @param value value of the new variable
+	 * @throws OpenShiftSSHOperationException - if the variable already exists
 	 */
 	public IEnvironmentVariable addEnvironmentVariable(String name, String value) throws OpenShiftException;
 
 	/**
 	 * Adds a map of environment variables to the application
 	 * 
-	 * @param environmentVariables
-	 *            map of environment variables
+	 * @param environmentVariables Map<String,String> of environment variables
 	 * @throws OpenShiftSSHOperationException
 	 */
 	public Map<String, IEnvironmentVariable> addEnvironmentVariables(Map<String, String> environmentVariables)
@@ -463,42 +460,47 @@ public interface IApplication extends IOpenShiftResource {
 	/**
 	 * Return the environment variable for the specified name
 	 * 
-	 * @param name
-	 *            Name of the environment variable
-	 * @return environment variable
-	 * @throws OpenShiftSSHOperationException
+	 * @param name key to be used to locate the environment variable
+	 * @return IEnvironmentVariable associated with the provided key
+	 * @throws OpenShiftSSHOperationException - thrown if the key does not exist
 	 */
 	public IEnvironmentVariable getEnvironmentVariable(String name) throws OpenShiftException;
 
 	/**
 	 * Removes the environment variables with the given name from this application.
 	 * 
-	 * @param name
-	 * @return
-	 * @throws OpenShiftException
+	 * @param name key associated with the IEnvironmentVariable to be removed
+	 * @return 
+	 * @throws OpenShiftException - thrown if there is no IEnvironmentVariable associated with the explicit parameter.
 	 */
 	public void removeEnvironmentVariable(String name) throws OpenShiftException;
+	
+	/**
+     * Removes the environment variables with the given name from this application.
+     * 
+     * @param environmentVariable IEnvironmentVariable instance which should be removed
+     * @return 
+     * @throws OpenShiftException - thrown if there is no instance  of IEnvironmentVariable available to be removed
+     */
+	public void removeEnvironmentVariable(IEnvironmentVariable environmentVariable);
 
 	/**
-	 * Returns <code>true</code> if this application can list its environment
-	 * variables. Returns <code>false</code> if it cant. Internally this
-	 * translates to the presence of the link to list environment variables.
+	 * Used to determine if environment variables exist and are available to be retrieved 
 	 * 
-	 * @return true if this application can list its envirnoment variables
+	 * @return Returns <code>true</code> if this application can list its environment variables. <br>
+	 *         Returns <code>false</code> if it cannot. Internally this translates to the presence of the link to list environment variables.
 	 * 
-	 * @see #getEnvironmentVariables()
+	 * @see #getEnvironmentVariablesMap()
 	 * @see #getEnvironmentVariable(String)
 	 * @see ApplicationResource#LINK_LIST_ENVIRONMENT_VARIABLES
 	 */
 	public boolean canGetEnvironmentVariables();
 
 	/**
-	 * Returns <code>true</code> if this application can update (set or unset)
-	 * its environment variables. Returns <code>false</code> if it cannot.
-	 * Internally this translates to the presence of the link to set and unset
-	 * environment variables.
+	 * Used to determine if the current instance is able to update environment variables.
 	 * 
-	 * @return true if this application can set/unset its environment variables
+	 * @return Returns <code>true</code> if this application can augment its environment variables.<br>
+     *         Returns <code>false</code> if it cannot. <br>
 	 * 
 	 * @see #addEnvironmentVariable(String, String)
 	 * @see #addEnvironmentVariables(Map)

--- a/src/main/java/com/openshift/internal/client/EnvironmentVariableResource.java
+++ b/src/main/java/com/openshift/internal/client/EnvironmentVariableResource.java
@@ -61,14 +61,22 @@ public class EnvironmentVariableResource extends AbstractOpenShiftResource imple
 	}
 
 	@Override
-	public void update(String value) throws OpenShiftException {
-		if (value == null) {
+	public void update(String newValue) throws OpenShiftException {
+		if (newValue == null) {
 			throw new OpenShiftException("Value for environment variable \"{0}\" not given.", name);
 		}
 		EnvironmentVariableResourceDTO environmentVariableResourceDTO = 
-				new UpdateEnvironmentVariableRequest().execute(value);
+				new UpdateEnvironmentVariableRequest().execute(newValue);
 		updateEnvironmentVariable(environmentVariableResourceDTO);
+		/*
+		 * This should be done in the IApplication, to break up this dependency
+		 * on the entity, i.e. IEnvironmentVariable, on something that is 
+		 * outside of itself, such as the implementation of IApplication.
+		 * @author Martes G Wigglesworth
+		 */
 		application.updateEnvironmentVariables();
+		
+		
 	}
 
 	private void updateEnvironmentVariable(EnvironmentVariableResourceDTO dto) {
@@ -81,7 +89,7 @@ public class EnvironmentVariableResource extends AbstractOpenShiftResource imple
 	@Override
 	public void destroy() throws OpenShiftException {
 		new DeleteEnvironmentVariableRequest().execute();
-		application.updateEnvironmentVariables();
+		
 	}
 
 	@Override
@@ -118,5 +126,10 @@ public class EnvironmentVariableResource extends AbstractOpenShiftResource imple
 	public IApplication getApplication() {
 		return application;
 	}
-	
+
+	public String toString(){
+		return new String(
+				"Name:"+this.name+",Value:"+value
+				);
+	}
 }

--- a/src/test/java/com/openshift/internal/client/ApplicationResourceIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/client/ApplicationResourceIntegrationTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
@@ -43,6 +44,7 @@ import com.openshift.client.utils.TestConnectionFactory;
 /**
  * @author André Dietisheim
  * @author Syed Iqbal
+ * @author Martes G Wigglesworth 
  */
 public class ApplicationResourceIntegrationTest {
 
@@ -336,22 +338,6 @@ public class ApplicationResourceIntegrationTest {
 	}
 
     @Test
-	public void shouldDestroyEnvironmentVariable() throws Throwable{
-    	//pre-conditions
-    	IApplication application = ApplicationTestUtils.getOrCreateApplication(domain);
-		ApplicationTestUtils.destroyAllEnvironmentVariables(application);
-    	IEnvironmentVariable environmentVariable = application.addEnvironmentVariable("FOOBAR","123");
-    	assertThat(application.getEnvironmentVariables().size()).isEqualTo(1);
-    	
-    	//operation
-    	environmentVariable.destroy();
-    	
-    	//verification
-    	assertThat(application.getEnvironmentVariables().size()).isEqualTo(0);
-    	assertThat(application.hasEnvironmentVariable("FOOBAR")).isFalse();
-    }
-
-    @Test
 	public void shouldRemoveEnvironmentVariable() throws Throwable{
     	//pre-conditions
     	IApplication application = ApplicationTestUtils.getOrCreateApplication(domain);
@@ -361,6 +347,22 @@ public class ApplicationResourceIntegrationTest {
     	
     	//operation
     	application.removeEnvironmentVariable(environmentVariable.getName());
+    	
+    	//verification
+    	assertThat(application.getEnvironmentVariables().size()).isEqualTo(0);
+    	assertThat(application.hasEnvironmentVariable("FOOBAR")).isFalse();
+    }
+    
+    @Test
+	public void shouldRemoveEnvironmentVariableByInstance() throws Throwable{
+    	//pre-conditions
+    	IApplication application = ApplicationTestUtils.getOrCreateApplication(domain);
+		ApplicationTestUtils.destroyAllEnvironmentVariables(application);
+    	IEnvironmentVariable environmentVariable = application.addEnvironmentVariable("FOOBAR","123");
+    	assertThat(application.getEnvironmentVariables().size()).isEqualTo(1);
+    	
+    	//operation
+    	application.removeEnvironmentVariable(environmentVariable);
     	
     	//verification
     	assertThat(application.getEnvironmentVariables().size()).isEqualTo(0);
@@ -383,37 +385,39 @@ public class ApplicationResourceIntegrationTest {
 		}
 	}
 
-	@Test
-	public void shouldListAllEnvironmentVariables() throws Throwable {
-		// preconditions
-		ApplicationTestUtils.silentlyDestroyAllApplications(domain);
-		IApplication application = ApplicationTestUtils.getOrCreateApplication(domain);
-		Map<String, String> environmentVariableMap = new HashMap<String, String>();
-		environmentVariableMap.put("X_NAME", "X_VALUE");
-		environmentVariableMap.put("Y_NAME", "Y_VALUE");
-		environmentVariableMap.put("Z_NAME", "Z_VALUE");
-		application.addEnvironmentVariables(environmentVariableMap);
-
-		// operation
-		Map<String, IEnvironmentVariable> environmentVariables = application.getEnvironmentVariables();
-
-		// verifications
-		assertThat(environmentVariables).hasSize(3);
-	}
 	
 	@Test
-	public void shouldLoadEmptyListOfEnvironmentVariables() throws Throwable{
-		//precondition
-		ApplicationTestUtils.silentlyDestroyAllApplications(domain);
-		IApplication application = ApplicationTestUtils.getOrCreateApplication(domain);
+    public void shouldGetMapOfAllEnvironmentVariables() throws Throwable {
+        // preconditions
+        ApplicationTestUtils.silentlyDestroyAllApplications(domain);
+        IApplication application = ApplicationTestUtils.getOrCreateApplication(domain);
+        Map<String, String> environmentVariableMap = new HashMap<String, String>();
+        environmentVariableMap.put("X_NAME", "X_VALUE");
+        environmentVariableMap.put("Y_NAME", "Y_VALUE");
+        environmentVariableMap.put("Z_NAME", "Z_VALUE");
+        application.addEnvironmentVariables(environmentVariableMap);
 
-		//operation
-		Map<String, IEnvironmentVariable> environmentVariables = application.getEnvironmentVariables();
+        // operation
+        Map<String, IEnvironmentVariable> environmentVariables = application.getEnvironmentVariables();
 
-		//verifications
-		assertThat(environmentVariables).isEmpty();
-	}
+        // verifications
+        assertThat(environmentVariables).hasSize(3);
+    }
+    
 	
+    @Test
+    public void shouldLoadEmptyMapOfEnvironmentVariables() throws Throwable{
+        //precondition
+        ApplicationTestUtils.silentlyDestroyAllApplications(domain);
+        IApplication application = ApplicationTestUtils.getOrCreateApplication(domain);
+
+        //operation
+        Map<String, IEnvironmentVariable> environmentVariables = application.getEnvironmentVariables();
+
+        //verifications
+        assertThat(environmentVariables).isEmpty();
+    }
+
 	@Test
 	public void shouldCanGetCanUpdateEnvironmentVariables() throws Throwable {
 		// pre-conditions

--- a/src/test/java/com/openshift/internal/client/ApplicationResourceTest.java
+++ b/src/test/java/com/openshift/internal/client/ApplicationResourceTest.java
@@ -564,7 +564,7 @@ public class ApplicationResourceTest {
 	}
 
 	@Test
-	public void shouldCanListEnvironmentVariables() throws Throwable {
+	public void shouldCanGetEnvironmentVariables() throws Throwable {
 		// pre-conditions
 		mockDirector
 				.mockAddEnvironmentVariable("foobarz", "springeap6",
@@ -639,11 +639,9 @@ public class ApplicationResourceTest {
 				.mockGetEnvironmentVariables("foobarz", "springeap6",
 						GET_1_ENVIRONMENT_VARIABLES_FOOBARZ_SPRINGEAP6, GET_2_ENVIRONMENT_VARIABLES_FOOBARZ_SPRINGEAP6);
 		final IApplication app = domain.getApplicationByName("springeap6");
-		Map<String, IEnvironmentVariable> environmentVariables = app.getEnvironmentVariables();
-		assertThat(environmentVariables).hasSize(1);
+		assertThat(app.getEnvironmentVariables()).hasSize(1);
 		// operation
 		app.refresh();
-		
 		// verification
 		assertThat(app.getEnvironmentVariables()).hasSize(2);
 	}
@@ -685,25 +683,42 @@ public class ApplicationResourceTest {
 	}
 
 	@Test
-	public void shouldRemoveEnvironmentVariable() throws Throwable {
+	public void shouldRemoveEnvironmentVariableByName() throws Throwable {
 		// precondition
 		mockDirector.mockGetEnvironmentVariables("foobarz", "springeap6",
 				GET_1_ENVIRONMENT_VARIABLES_FOOBARZ_SPRINGEAP6, GET_0_ENVIRONMENT_VARIABLES_FOOBARZ_SPRINGEAP6);
 		final IApplication app = domain.getApplicationByName("springeap6");
 		assertThat(app.getEnvironmentVariables()).hasSize(1);
-		IEnvironmentVariable existingEnvironmentVariable = app.getEnvironmentVariables().get("FOO");
-		assertThat(existingEnvironmentVariable.getName()).isEqualTo("FOO");
+		assertThat(app.getEnvironmentVariables().get("FOO").getName() == "FOO");
 
 		// operation
-		existingEnvironmentVariable.destroy();
+		app.removeEnvironmentVariable("FOO");
 		
 		// verification
 		assertThat(app.getEnvironmentVariables()).hasSize(0);
 		assertThat(app.hasEnvironmentVariable("FOO")).isFalse();
 	}
+	
+	@Test
+    public void shouldRemoveEnvironmentVariable() throws Throwable {
+        // precondition
+        mockDirector.mockGetEnvironmentVariables("foobarz", "springeap6",
+                GET_1_ENVIRONMENT_VARIABLES_FOOBARZ_SPRINGEAP6, GET_0_ENVIRONMENT_VARIABLES_FOOBARZ_SPRINGEAP6);
+        final IApplication app = domain.getApplicationByName("springeap6");
+        assertThat(app.getEnvironmentVariables()).hasSize(1);
+        IEnvironmentVariable environmentVariable = app.getEnvironmentVariables().get("FOO");
+        assertThat(environmentVariable.getName()).isEqualTo("FOO");
+
+        // operation
+        app.removeEnvironmentVariable(environmentVariable);
+        
+        // verification
+        assertThat(app.getEnvironmentVariables()).hasSize(0);
+        assertThat(app.hasEnvironmentVariable("FOO")).isFalse();
+    }
 
 	@Test
-	public void shouldListAllEnvironmentVariablesFromApplication() throws Throwable {
+	public void shouldGetMapOfAllEnvironmentVariablesFromApplication() throws Throwable {
 		// preconditions
 		mockDirector.mockGetEnvironmentVariables("foobarz", "springeap6",
 				GET_4_ENVIRONMENT_VARIABLES_FOOBARZ_SPRINGEAP6);
@@ -719,7 +734,7 @@ public class ApplicationResourceTest {
 	}
 
 	@Test
-	public void shouldLoadEmptyListOfEnvironmentVariables() throws Throwable {
+	public void shouldLoadEmptyMapOfEnvironmentVariables() throws Throwable {
 		// precondition
 		mockDirector
 			.mockGetEnvironmentVariables("foobarz", "springeap6", GET_0_ENVIRONMENT_VARIABLES_FOOBARZ_SPRINGEAP6);
@@ -755,5 +770,6 @@ public class ApplicationResourceTest {
 		assertThat(domain).isEqualTo(this.domain);
 		assertTrue(domain != this.domain);
 	}
+
 
 }

--- a/src/test/java/com/openshift/internal/client/EnvironmentVariableResourceIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/client/EnvironmentVariableResourceIntegrationTest.java
@@ -70,7 +70,8 @@ public class EnvironmentVariableResourceIntegrationTest {
 		application.addEnvironmentVariable("Z_NAME", "Z_VALUE");
 		// operation
 		IEnvironmentVariable zEnvironmentVariable = application.getEnvironmentVariable("Z_NAME");
-		zEnvironmentVariable.destroy();
+		application.removeEnvironmentVariable(zEnvironmentVariable);
+		//application.refresh();
 		zEnvironmentVariable = application.getEnvironmentVariable("Z_NAME");
 		assertThat(zEnvironmentVariable).isNull();
 	}

--- a/src/test/java/com/openshift/internal/client/EnvironmentVariableResourceTest.java
+++ b/src/test/java/com/openshift/internal/client/EnvironmentVariableResourceTest.java
@@ -26,6 +26,7 @@ import com.openshift.client.IEnvironmentVariable;
 
 /**
  * @author Syed Iqbal 
+ * @author Martes G Wigglesworth
  */
 public class EnvironmentVariableResourceTest {
 	
@@ -70,7 +71,8 @@ public class EnvironmentVariableResourceTest {
        //operation
       IEnvironmentVariable environmentVariable = application.getEnvironmentVariable("FOO");
       assertThat(environmentVariable).isNotNull();
-      environmentVariable.destroy();
+      application.removeEnvironmentVariable(environmentVariable);
+      application.refresh();
       environmentVariable = application.getEnvironmentVariable("FOO");
       assertThat(environmentVariable).isNull();
     }


### PR DESCRIPTION
Please reference the following change log:

Removed update calls from EnvironmentVariableResource.destroy,
ApplicationResource.addEnvironmentVariable,ApplicationResource.addEnvironmentVariables,and
ApplicationResource.removeEnvironmentVariable.

Added
ApplicationResource.removeEnvironmentVariable(IEnvironmentVariable)

Renamed environmentVariableByName to environmentVariableMap

Updated getOrLoadEnvironmentVariable to work check for emptiness of
environmentVariableMap

Updated loadEnvironmentVariables to work on environmentVariablesMap, and
return it, in contrast to a locally-scoped version that did not persist.

Corrected test failures due to omitted changes to instances methods for EnvironmentVariableResouce and ApplicationResource.

Updated remove methods to use remove..(IEnvironmentVariable) and
ApplicationResourceIntegrationTest to use
Application.removeEnvironmentVariable(IEnvironmentVariable) in testing.
Added integration test for
removeEnvironmentVariable(IEnvironmentVariable)

Updated ApplicationResource.addEnvironmentVariables(Map<String,String>) to filter the incoming map key/value pairs if they
are duplicate keys, without different values. This update should resolve unecessary update DTO requests being generated.

(Rebased up to Nov 12 since the original PR got behind.)

Corrected possible logical error that was accidentally included in addEnvinronmentVariables(Map<String,String>), with the original PR. [if(testVar!=null)...else....]

(Rebased again, to support merge with most recent version of upstream master: 13-NOV-2013)

Corrected ApplicationResource.removeEnvironmentVariableByInstance(IEnvironmentVariable) and ApplicationResource.removeEnvironmentVariable(String) to correct failing test(s).
