### PR TITLE
[DO_NOT_MERGE] Card origin_cartridge_22 - MongoDB version update to 2.4

### DIFF
--- a/src/test/java/com/openshift/client/utils/Cartridges.java
+++ b/src/test/java/com/openshift/client/utils/Cartridges.java
@@ -33,7 +33,7 @@ public class Cartridges {
 			"http://cartreflect-claytondev.rhcloud.com/reflect?github=smarterclayton/openshift-go-cart";
 
 	public static final String MYSQL_51_NAME = "mysql-5.1";
-	public static final String MONGODB_22_NAME = "mongodb-2.2";
+	public static final String MONGODB_24_NAME, = "mongodb-2.4";
 	public static final String FOREMAN_DOWNLOAD_URL =
 			"http://cartreflect-claytondev.rhcloud.com/reflect?github=ncdc/openshift-foreman-cartridge";
 	public static final String SWITCHYARD_06_NAME = "switchyard-0.6";
@@ -69,8 +69,8 @@ public class Cartridges {
 		return new EmbeddableCartridge(MYSQL_51_NAME);
 	}
 
-	public static IEmbeddableCartridge mongodb22() {
-		return new EmbeddableCartridge(MONGODB_22_NAME);
+	public static IEmbeddableCartridge mongodb24() {
+		return new EmbeddableCartridge(MONGODB_24_NAME,);
 	}
 
 	public static IEmbeddableCartridge postgres84() {

--- a/src/test/java/com/openshift/internal/client/APIResourceTest.java
+++ b/src/test/java/com/openshift/internal/client/APIResourceTest.java
@@ -50,7 +50,7 @@ public class APIResourceTest {
 						, Cartridges.JBOSSEAP_6_NAME
 						, Cartridges.JBOSSEWS_1_NAME
 						, Cartridges.JBOSSEWS_2_NAME)
-				.excludes(Cartridges.MONGODB_22_NAME
+				.excludes(Cartridges.MONGODB_24_NAME,
 						, Cartridges.MYSQL_51_NAME
 						, Cartridges.SWITCHYARD_06_NAME);
 	}
@@ -69,7 +69,7 @@ public class APIResourceTest {
 						, Cartridges.JBOSSEAP_6_NAME
 						, Cartridges.JBOSSEWS_1_NAME
 						, Cartridges.JBOSSEWS_2_NAME)
-				.contains(Cartridges.MONGODB_22_NAME
+				.contains(Cartridges.MONGODB_24_NAME,
 						, Cartridges.MYSQL_51_NAME
 						, Cartridges.SWITCHYARD_06_NAME);
 	}

--- a/src/test/java/com/openshift/internal/client/ApplicationResourceTest.java
+++ b/src/test/java/com/openshift/internal/client/ApplicationResourceTest.java
@@ -328,7 +328,7 @@ public class ApplicationResourceTest {
 		// pre-conditions
 		// operation
 		final IApplication app = domain.getApplicationByName("springeap6");
-		IEmbeddedCartridge mongo = app.getEmbeddedCartridge(Cartridges.mongodb22());
+		IEmbeddedCartridge mongo = app.getEmbeddedCartridge(Cartridges.mongodb24());
 		// verifications
 		// embedded cartridge should get updated with name, description and
 		// display name

--- a/src/test/java/com/openshift/internal/client/DomainResourceTest.java
+++ b/src/test/java/com/openshift/internal/client/DomainResourceTest.java
@@ -12,7 +12,7 @@ package com.openshift.internal.client;
 
 import static com.openshift.client.utils.Cartridges.JBOSSAS_7_NAME;
 import static com.openshift.client.utils.Cartridges.JENKINS_14_NAME;
-import static com.openshift.client.utils.Cartridges.MONGODB_22_NAME;
+import static com.openshift.client.utils.Cartridges.MONGODB_24_NAME,;
 import static com.openshift.client.utils.Samples.DELETE_DOMAINS_FOOBARZ;
 import static com.openshift.client.utils.Samples.GET_DOMAINS_EMPTY;
 import static com.openshift.client.utils.Samples.GET_DOMAINS_FOOBARS;
@@ -506,7 +506,7 @@ public class DomainResourceTest {
 				GearProfile.LARGE, 
 				"git://github.com/adietish/openshift-java-client.git", 
 				42001, 
-				Cartridges.mongodb22(), 
+				Cartridges.mongodb24(), 
 				Cartridges.mysql51());
 		
 		// verification
@@ -522,7 +522,7 @@ public class DomainResourceTest {
 								.add(new ParameterValueMap().add(IOpenShiftJsonConstants.PROPERTY_NAME,
 										JENKINS_14_NAME))
 								.add(new ParameterValueMap().add(IOpenShiftJsonConstants.PROPERTY_NAME,
-										MONGODB_22_NAME))
+										MONGODB_24_NAME,))
 								.add(new ParameterValueMap().add(IOpenShiftJsonConstants.PROPERTY_NAME,
 										Cartridges.MYSQL_51_NAME))));
 	}

--- a/src/test/java/com/openshift/internal/client/EmbeddableCartridgeTest.java
+++ b/src/test/java/com/openshift/internal/client/EmbeddableCartridgeTest.java
@@ -94,7 +94,7 @@ public class EmbeddableCartridgeTest {
 		// operation
 		// verifcation
 		cartridgeAssert
-				.hasName("mongodb-2.2")
+				.hasName("mongodb-2.4")
 				.hasDisplayName("MongoDB NoSQL Database 2.2")
 				.hasDescription("MongoDB is a scalable, high-performance, open source NoSQL database.");
 	}

--- a/src/test/java/com/openshift/internal/client/EmbeddedCartridgeResourceTest.java
+++ b/src/test/java/com/openshift/internal/client/EmbeddedCartridgeResourceTest.java
@@ -122,7 +122,7 @@ public class EmbeddedCartridgeResourceTest {
 	public void shouldHaveUrlProperty() throws Throwable {
 		// pre-conditions
 		// operation
-		IEmbeddedCartridge mongo = application.getEmbeddedCartridge(Cartridges.MONGODB_22_NAME);
+		IEmbeddedCartridge mongo = application.getEmbeddedCartridge(Cartridges.MONGODB_24_NAME,);
 		IEmbeddedCartridge mysql = application.getEmbeddedCartridge(Cartridges.MYSQL_51_NAME);
 
 		// verifications

--- a/src/test/java/com/openshift/internal/client/GearGroupsResourceTest.java
+++ b/src/test/java/com/openshift/internal/client/GearGroupsResourceTest.java
@@ -63,11 +63,11 @@ public class GearGroupsResourceTest {
 				.assertGear("514207b84382ec1fef000098").inState(GearState.IDLE)
 				.assertGear("514207b84382ec1fef000098").hasSshUrl("ssh://52380549e0b8cd1e0e000032@springeap6-foobarz.rhcloud.com")
 				.assertGear("5146f047500446f12d00002e").inState(GearState.BUILDING)
-				.hasCartridges("jbosseap-6", "mongodb-2.2");
+				.hasCartridges("jbosseap-6", "mongodb-2.4");
 		assertThat(new GearGroupsAssert(gearGroups)).assertGroup("514212ce500446b64e0000c0")
 				.hasUUID("514212ce500446b64e0000c0")
 				.assertGear("514212ce500446b64e0000b4").hasSshUrl("ssh://523809b75973ca569600019b@523809b75973ca569600019b-foobarz.rhcloud.com")
 				.assertGear("514212ce500446b64e0000b4").inState(GearState.DEPLOYING)
-				.hasCartridges("mongodb-2.2");
+				.hasCartridges("mongodb-2.4");
 	}
 }

--- a/src/test/java/com/openshift/internal/client/response/OpenShiftJsonDTOFactoryTest.java
+++ b/src/test/java/com/openshift/internal/client/response/OpenShiftJsonDTOFactoryTest.java
@@ -225,13 +225,13 @@ public class OpenShiftJsonDTOFactoryTest {
 		assertThat(applicationDTO.getUuid()).isEqualTo("523cbe15e0b8cd0a520001b6");
 		assertThat(applicationDTO.getCartridges().keySet()).containsOnly(
 				Cartridges.JBOSSEAP_6_NAME,
-				Cartridges.MONGODB_22_NAME,
+				Cartridges.MONGODB_24_NAME,,
 				Cartridges.MYSQL_51_NAME);
 		CartridgeResourceDTO cartridgeResourceDTO = 
-				applicationDTO.getCartridges().get(Cartridges.MONGODB_22_NAME);
+				applicationDTO.getCartridges().get(Cartridges.MONGODB_24_NAME,);
 		assertThat(cartridgeResourceDTO).isNotNull();
 		assertThat(cartridgeResourceDTO.getType()).isEqualTo(CartridgeType.EMBEDDED);
-		assertThat(cartridgeResourceDTO.getName()).isEqualTo(Cartridges.MONGODB_22_NAME);
+		assertThat(cartridgeResourceDTO.getName()).isEqualTo(Cartridges.MONGODB_24_NAME,);
 		assertThat(cartridgeResourceDTO.getDescription()).startsWith("MongoDB is a scalable, high-performance, "); 
 		assertThat(cartridgeResourceDTO.getDisplayName()).startsWith("MongoDB NoSQL Database "); 
 		assertThat(cartridgeResourceDTO.getMessages()).isNull(); // dito
@@ -358,7 +358,7 @@ public class OpenShiftJsonDTOFactoryTest {
 		final Map<String, CartridgeResourceDTO> cartridges = response.getData();
 		assertThat(cartridges).hasSize(3); // mysql, mongo, jbosseap
 		assertThat(cartridges.values()).onProperty("name").containsOnly(
-				Cartridges.MONGODB_22_NAME,
+				Cartridges.MONGODB_24_NAME,,
 				Cartridges.MYSQL_51_NAME,
 				Cartridges.JBOSSEAP_6_NAME);
 	}
@@ -376,7 +376,7 @@ public class OpenShiftJsonDTOFactoryTest {
 		Map<String, CartridgeResourceDTO> cartridges = response.getData();
 		assertThat(cartridges).hasSize(3);
 		assertThat(cartridges.values()).onProperty("name").containsOnly(
-				Cartridges.MONGODB_22_NAME,
+				Cartridges.MONGODB_24_NAME,,
 				Cartridges.MYSQL_51_NAME,
 				Cartridges.JBOSSEAP_6_NAME);
 	}

--- a/src/test/resources/samples/get-cartridges.json
+++ b/src/test/resources/samples/get-cartridges.json
@@ -11,7 +11,7 @@
          ],
          "license":"ASL 2.0",
          "license_url":"http://www.apache.org/licenses/LICENSE-2.0.txt",
-         "name":"mongodb-2.2",
+         "name":"mongodb-2.4",
          "scales_from":1,
          "scales_to":1,
          "scales_with":"haproxy-1.4",

--- a/src/test/resources/samples/get-domains-foobars.json
+++ b/src/test/resources/samples/get-domains-foobars.json
@@ -30,7 +30,7 @@
             "optional_params":[
                {
                   "default_value":null,
-                  "description":"Array of one or more cartridge names. i.e. [\"php-5.3\", \"mongodb-2.2\"]",
+                  "description":"Array of one or more cartridge names. i.e. [\"php-5.3\", \"mongodb-2.4\"]",
                   "name":"cartridges",
                   "type":"array",
                   "valid_options":[

--- a/src/test/resources/samples/get-domains-foobarz-applications-downloadablecart.json
+++ b/src/test/resources/samples/get-domains-foobarz-applications-downloadablecart.json
@@ -956,7 +956,7 @@
             "rel":"Add embedded cartridge",
             "required_params":[
                {
-                  "description":"framework-type, e.g.: mongodb-2.2",
+                  "description":"framework-type, e.g.: mongodb-2.4",
                   "invalid_options":[
 
                   ],
@@ -973,7 +973,7 @@
                      "haproxy-1.4",
                      "postgresql-9.2",
                      "postgresql-8.4",
-                     "mongodb-2.2",
+                     "mongodb-2.4",
                      "jenkins-client-1",
                      "andygoldstein-foreman-0.63.0"
                   ]

--- a/src/test/resources/samples/get-domains-foobarz-applications-springeap6-cartidges-mysql.json
+++ b/src/test/resources/samples/get-domains-foobarz-applications-springeap6-cartidges-mysql.json
@@ -4,7 +4,7 @@
       "base_gear_storage":1,
       "collocated_with":[
          "jbosseap-6",
-         "mongodb-2.2"
+         "mongodb-2.4"
       ],
       "current_scale":1,
       "description":"MySQL is a multi-user, multi-threaded SQL database server.",

--- a/src/test/resources/samples/get-domains-foobarz-applications-springeap6-cartridges_1embedded.json
+++ b/src/test/resources/samples/get-domains-foobarz-applications-springeap6-cartridges_1embedded.json
@@ -4,7 +4,7 @@
          "additional_gear_storage":0,
          "base_gear_storage":1,
          "collocated_with":[
-            "mongodb-2.2"
+            "mongodb-2.4"
          ],
          "current_scale":1,
          "description":"Market-leading open source enterprise platform for next-generation, highly transactional enterprise Java applications. Build and deploy enterprise Java in the cloud.",
@@ -260,7 +260,7 @@
          "license_url":"http://www.apache.org/licenses/LICENSE-2.0.txt",
          "links":{
             "GET":{
-               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                "method":"GET",
                "optional_params":[
 
@@ -271,12 +271,12 @@
                ]
             },
             "UPDATE":{
-               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                "method":"PUT",
                "optional_params":[
                   {
                      "default_value":null,
-                     "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.2",
+                     "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.4",
                      "name":"additional_gear_storage",
                      "type":"integer",
                      "valid_options":[
@@ -285,7 +285,7 @@
                   },
                   {
                      "default_value":null,
-                     "description":"Minimum number of gears having cartridge mongodb-2.2",
+                     "description":"Minimum number of gears having cartridge mongodb-2.4",
                      "name":"scales_from",
                      "type":"integer",
                      "valid_options":[
@@ -294,7 +294,7 @@
                   },
                   {
                      "default_value":null,
-                     "description":"Maximum number of gears having cartridge mongodb-2.2",
+                     "description":"Maximum number of gears having cartridge mongodb-2.4",
                      "name":"scales_to",
                      "type":"integer",
                      "valid_options":[
@@ -308,7 +308,7 @@
                ]
             },
             "START":{
-               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                "method":"POST",
                "optional_params":[
 
@@ -329,7 +329,7 @@
                ]
             },
             "STOP":{
-               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                "method":"POST",
                "optional_params":[
 
@@ -350,7 +350,7 @@
                ]
             },
             "RESTART":{
-               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                "method":"POST",
                "optional_params":[
 
@@ -371,7 +371,7 @@
                ]
             },
             "RELOAD":{
-               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                "method":"POST",
                "optional_params":[
 
@@ -392,7 +392,7 @@
                ]
             },
             "DELETE":{
-               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                "method":"DELETE",
                "optional_params":[
 
@@ -403,7 +403,7 @@
                ]
             }
          },
-         "name":"mongodb-2.2",
+         "name":"mongodb-2.4",
          "properties":[
             {
                "name":"username",

--- a/src/test/resources/samples/get-domains-foobarz-applications-springeap6-cartridges_2embedded.json
+++ b/src/test/resources/samples/get-domains-foobarz-applications-springeap6-cartridges_2embedded.json
@@ -4,7 +4,7 @@
          "additional_gear_storage":0,
          "base_gear_storage":1,
          "collocated_with":[
-            "mongodb-2.2",
+            "mongodb-2.4",
             "mysql-5.1"
          ],
          "current_scale":1,
@@ -262,7 +262,7 @@
          "license_url":"http://www.apache.org/licenses/LICENSE-2.0.txt",
          "links":{
             "GET":{
-               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                "method":"GET",
                "optional_params":[
 
@@ -273,12 +273,12 @@
                ]
             },
             "UPDATE":{
-               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                "method":"PUT",
                "optional_params":[
                   {
                      "default_value":null,
-                     "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.2",
+                     "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.4",
                      "name":"additional_gear_storage",
                      "type":"integer",
                      "valid_options":[
@@ -287,7 +287,7 @@
                   },
                   {
                      "default_value":null,
-                     "description":"Minimum number of gears having cartridge mongodb-2.2",
+                     "description":"Minimum number of gears having cartridge mongodb-2.4",
                      "name":"scales_from",
                      "type":"integer",
                      "valid_options":[
@@ -296,7 +296,7 @@
                   },
                   {
                      "default_value":null,
-                     "description":"Maximum number of gears having cartridge mongodb-2.2",
+                     "description":"Maximum number of gears having cartridge mongodb-2.4",
                      "name":"scales_to",
                      "type":"integer",
                      "valid_options":[
@@ -310,7 +310,7 @@
                ]
             },
             "START":{
-               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                "method":"POST",
                "optional_params":[
 
@@ -331,7 +331,7 @@
                ]
             },
             "STOP":{
-               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                "method":"POST",
                "optional_params":[
 
@@ -352,7 +352,7 @@
                ]
             },
             "RESTART":{
-               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                "method":"POST",
                "optional_params":[
 
@@ -373,7 +373,7 @@
                ]
             },
             "RELOAD":{
-               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                "method":"POST",
                "optional_params":[
 
@@ -394,7 +394,7 @@
                ]
             },
             "DELETE":{
-               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+               "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                "method":"DELETE",
                "optional_params":[
 
@@ -405,7 +405,7 @@
                ]
             }
          },
-         "name":"mongodb-2.2",
+         "name":"mongodb-2.4",
          "properties":[
             {
                "name":"username",
@@ -456,7 +456,7 @@
          "base_gear_storage":1,
          "collocated_with":[
             "jbosseap-6",
-            "mongodb-2.2"
+            "mongodb-2.4"
          ],
          "current_scale":1,
          "description":"MySQL is a multi-user, multi-threaded SQL database server.",

--- a/src/test/resources/samples/get-domains-foobarz-applications-springeap6-geargroups.json
+++ b/src/test/resources/samples/get-domains-foobarz-applications-springeap6-geargroups.json
@@ -20,7 +20,7 @@
 					"username":"admin",
 					"password":"NNxXMT1z8dVj",
 					"database_name":"springeap6",
-					"name":"mongodb-2.2",
+					"name":"mongodb-2.4",
 					"display_name":"MongoDB NoSQL Database 2.2",
 					"tags":[
 						"service",
@@ -99,7 +99,7 @@
 					"username":"admin",
 					"password":"DLCVKnnzuGfF",
 					"database_name":"sringeap6",
-					"name":"mongodb-2.2",
+					"name":"mongodb-2.4",
 					"display_name":"MongoDB NoSQL Database 2.2",
 					"tags":[
 						"service",
@@ -118,7 +118,7 @@
 					"port_interfaces":[
 						{
 							"_id":"52380a0a5973ca56960001b0",
-							"cartridge_name":"mongodb-2.2",
+							"cartridge_name":"mongodb-2.4",
 							"external_address":"174.129.147.144",
 							"external_port":"52931",
 							"internal_address":"127.7.198.1",

--- a/src/test/resources/samples/get-domains-foobarz-applications-springeap6_0alias.json
+++ b/src/test/resources/samples/get-domains-foobarz-applications-springeap6_0alias.json
@@ -9,7 +9,7 @@
       "creation_time":"2013-04-30T17:00:41Z",
       "domain_id":"foobarz",
       "embedded":{
-         "mongodb-2.2":{
+         "mongodb-2.4":{
             "connection_url":"mongodb://$OPENSHIFT_MONGODB_DB_HOST:$OPENSHIFT_MONGODB_DB_PORT/",
             "username":"admin",
             "password":"NNxXMT1z8dVj",
@@ -332,7 +332,7 @@
                   "type":"string",
                   "valid_options":[
                      "jbosseap-6",
-                     "mongodb-2.2"
+                     "mongodb-2.4"
                   ]
                },
                {
@@ -373,7 +373,7 @@
                   "name":"name",
                   "type":"string",
                   "valid_options":[
-                     "mongodb-2.2",
+                     "mongodb-2.4",
                      "switchyard-0.6",
                      "cron-1.4",
                      "mysql-5.1",

--- a/src/test/resources/samples/get-domains-foobarz-applications-springeap6_1embedded.json
+++ b/src/test/resources/samples/get-domains-foobarz-applications-springeap6_1embedded.json
@@ -13,7 +13,7 @@
             "additional_gear_storage":0,
             "base_gear_storage":1,
             "collocated_with":[
-               "mongodb-2.2"
+               "mongodb-2.4"
             ],
             "current_scale":1,
             "description":"Market-leading open source enterprise platform for next-generation, highly transactional enterprise Java applications. Build and deploy enterprise Java in the cloud.",
@@ -266,7 +266,7 @@
             "license_url":"",
             "links":{
                "GET":{
-                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                   "method":"GET",
                   "optional_params":[
 
@@ -277,12 +277,12 @@
                   ]
                },
                "UPDATE":{
-                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                   "method":"PUT",
                   "optional_params":[
                      {
                         "default_value":null,
-                        "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.2",
+                        "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.4",
                         "name":"additional_gear_storage",
                         "type":"integer",
                         "valid_options":[
@@ -291,7 +291,7 @@
                      },
                      {
                         "default_value":null,
-                        "description":"Minimum number of gears having cartridge mongodb-2.2",
+                        "description":"Minimum number of gears having cartridge mongodb-2.4",
                         "name":"scales_from",
                         "type":"integer",
                         "valid_options":[
@@ -300,7 +300,7 @@
                      },
                      {
                         "default_value":null,
-                        "description":"Maximum number of gears having cartridge mongodb-2.2",
+                        "description":"Maximum number of gears having cartridge mongodb-2.4",
                         "name":"scales_to",
                         "type":"integer",
                         "valid_options":[
@@ -314,7 +314,7 @@
                   ]
                },
                "START":{
-                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                   "method":"POST",
                   "optional_params":[
 
@@ -335,7 +335,7 @@
                   ]
                },
                "STOP":{
-                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                   "method":"POST",
                   "optional_params":[
 
@@ -356,7 +356,7 @@
                   ]
                },
                "RESTART":{
-                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                   "method":"POST",
                   "optional_params":[
 
@@ -377,7 +377,7 @@
                   ]
                },
                "RELOAD":{
-                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                   "method":"POST",
                   "optional_params":[
 
@@ -398,7 +398,7 @@
                   ]
                },
                "DELETE":{
-                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                   "method":"DELETE",
                   "optional_params":[
 
@@ -409,7 +409,7 @@
                   ]
                }
             },
-            "name":"mongodb-2.2",
+            "name":"mongodb-2.4",
             "properties":[
                {
                   "name":"username",
@@ -460,7 +460,7 @@
       "creation_time":"2013-09-20T21:28:53Z",
       "domain_id":"foobarz",
       "embedded":{
-         "mongodb-2.2":{
+         "mongodb-2.4":{
             "connection_url":"mongodb://$OPENSHIFT_MONGODB_DB_HOST:$OPENSHIFT_MONGODB_DB_PORT/",
             "username":"admin",
             "password":"VwFPWQEs1PEl",
@@ -783,7 +783,7 @@
                   "type":"string",
                   "valid_options":[
                      "jbosseap-6",
-                     "mongodb-2.2"
+                     "mongodb-2.4"
                   ]
                },
                {
@@ -826,7 +826,7 @@
             "rel":"Add embedded cartridge",
             "required_params":[
                {
-                  "description":"framework-type, e.g.: mongodb-2.2",
+                  "description":"framework-type, e.g.: mongodb-2.4",
                   "invalid_options":[
 
                   ],
@@ -843,7 +843,7 @@
                      "haproxy-1.4",
                      "postgresql-9.2",
                      "postgresql-8.4",
-                     "mongodb-2.2",
+                     "mongodb-2.4",
                      "jenkins-client-1"
                   ]
                }

--- a/src/test/resources/samples/get-domains-foobarz-applications-springeap6_2alias.json
+++ b/src/test/resources/samples/get-domains-foobarz-applications-springeap6_2alias.json
@@ -11,7 +11,7 @@
       "creation_time":"2013-04-30T17:00:41Z",
       "domain_id":"foobarz",
       "embedded":{
-         "mongodb-2.2":{
+         "mongodb-2.4":{
             "connection_url":"mongodb://$OPENSHIFT_MONGODB_DB_HOST:$OPENSHIFT_MONGODB_DB_PORT/",
             "username":"admin",
             "password":"NNxXMT1z8dVj",
@@ -334,7 +334,7 @@
                   "type":"string",
                   "valid_options":[
                      "jbosseap-6",
-                     "mongodb-2.2"
+                     "mongodb-2.4"
                   ]
                },
                {
@@ -375,7 +375,7 @@
                   "name":"name",
                   "type":"string",
                   "valid_options":[
-                     "mongodb-2.2",
+                     "mongodb-2.4",
                      "switchyard-0.6",
                      "cron-1.4",
                      "mysql-5.1",

--- a/src/test/resources/samples/get-domains-foobarz-applications-springeap6_2embedded.json
+++ b/src/test/resources/samples/get-domains-foobarz-applications-springeap6_2embedded.json
@@ -13,7 +13,7 @@
             "additional_gear_storage":0,
             "base_gear_storage":1,
             "collocated_with":[
-               "mongodb-2.2",
+               "mongodb-2.4",
                "mysql-5.1"
             ],
             "current_scale":1,
@@ -268,7 +268,7 @@
             "license_url":"",
             "links":{
                "GET":{
-                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                   "method":"GET",
                   "optional_params":[
 
@@ -279,12 +279,12 @@
                   ]
                },
                "UPDATE":{
-                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                   "method":"PUT",
                   "optional_params":[
                      {
                         "default_value":null,
-                        "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.2",
+                        "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.4",
                         "name":"additional_gear_storage",
                         "type":"integer",
                         "valid_options":[
@@ -293,7 +293,7 @@
                      },
                      {
                         "default_value":null,
-                        "description":"Minimum number of gears having cartridge mongodb-2.2",
+                        "description":"Minimum number of gears having cartridge mongodb-2.4",
                         "name":"scales_from",
                         "type":"integer",
                         "valid_options":[
@@ -302,7 +302,7 @@
                      },
                      {
                         "default_value":null,
-                        "description":"Maximum number of gears having cartridge mongodb-2.2",
+                        "description":"Maximum number of gears having cartridge mongodb-2.4",
                         "name":"scales_to",
                         "type":"integer",
                         "valid_options":[
@@ -316,7 +316,7 @@
                   ]
                },
                "START":{
-                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                   "method":"POST",
                   "optional_params":[
 
@@ -337,7 +337,7 @@
                   ]
                },
                "STOP":{
-                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                   "method":"POST",
                   "optional_params":[
 
@@ -358,7 +358,7 @@
                   ]
                },
                "RESTART":{
-                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                   "method":"POST",
                   "optional_params":[
 
@@ -379,7 +379,7 @@
                   ]
                },
                "RELOAD":{
-                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                   "method":"POST",
                   "optional_params":[
 
@@ -400,7 +400,7 @@
                   ]
                },
                "DELETE":{
-                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                  "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                   "method":"DELETE",
                   "optional_params":[
 
@@ -411,7 +411,7 @@
                   ]
                }
             },
-            "name":"mongodb-2.2",
+            "name":"mongodb-2.4",
             "properties":[
                {
                   "name":"username",
@@ -463,7 +463,7 @@
             "base_gear_storage":1,
             "collocated_with":[
                "jbosseap-6",
-               "mongodb-2.2"
+               "mongodb-2.4"
             ],
             "current_scale":1,
             "description":"MySQL is a multi-user, multi-threaded SQL database server.",
@@ -669,7 +669,7 @@
       "creation_time":"2013-09-20T21:28:53Z",
       "domain_id":"foobarz",
       "embedded":{
-         "mongodb-2.2":{
+         "mongodb-2.4":{
             "connection_url":"mongodb://$OPENSHIFT_MONGODB_DB_HOST:$OPENSHIFT_MONGODB_DB_PORT/",
             "username":"admin",
             "password":"VwFPWQEs1PEl",
@@ -999,7 +999,7 @@
                   "type":"string",
                   "valid_options":[
                      "jbosseap-6",
-                     "mongodb-2.2",
+                     "mongodb-2.4",
                      "mysql-5.1"
                   ]
                },
@@ -1043,7 +1043,7 @@
             "rel":"Add embedded cartridge",
             "required_params":[
                {
-                  "description":"framework-type, e.g.: mongodb-2.2",
+                  "description":"framework-type, e.g.: mongodb-2.4",
                   "invalid_options":[
 
                   ],
@@ -1060,7 +1060,7 @@
                      "haproxy-1.4",
                      "postgresql-9.2",
                      "postgresql-8.4",
-                     "mongodb-2.2",
+                     "mongodb-2.4",
                      "jenkins-client-1"
                   ]
                }

--- a/src/test/resources/samples/get-domains-foobarz-applications_1embedded.json
+++ b/src/test/resources/samples/get-domains-foobarz-applications_1embedded.json
@@ -793,7 +793,7 @@
                "rel":"Add embedded cartridge",
                "required_params":[
                   {
-                     "description":"framework-type, e.g.: mongodb-2.2",
+                     "description":"framework-type, e.g.: mongodb-2.4",
                      "invalid_options":[
 
                      ],
@@ -810,7 +810,7 @@
                         "haproxy-1.4",
                         "postgresql-9.2",
                         "postgresql-8.4",
-                        "mongodb-2.2",
+                        "mongodb-2.4",
                         "jenkins-client-1"
                      ]
                   }
@@ -905,7 +905,7 @@
                "additional_gear_storage":0,
                "base_gear_storage":1,
                "collocated_with":[
-                  "mongodb-2.2"
+                  "mongodb-2.4"
                ],
                "current_scale":1,
                "description":"Market-leading open source enterprise platform for next-generation, highly transactional enterprise Java applications. Build and deploy enterprise Java in the cloud.",
@@ -1158,7 +1158,7 @@
                "license_url":"",
                "links":{
                   "GET":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                      "method":"GET",
                      "optional_params":[
 
@@ -1169,12 +1169,12 @@
                      ]
                   },
                   "UPDATE":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                      "method":"PUT",
                      "optional_params":[
                         {
                            "default_value":null,
-                           "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.2",
+                           "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.4",
                            "name":"additional_gear_storage",
                            "type":"integer",
                            "valid_options":[
@@ -1183,7 +1183,7 @@
                         },
                         {
                            "default_value":null,
-                           "description":"Minimum number of gears having cartridge mongodb-2.2",
+                           "description":"Minimum number of gears having cartridge mongodb-2.4",
                            "name":"scales_from",
                            "type":"integer",
                            "valid_options":[
@@ -1192,7 +1192,7 @@
                         },
                         {
                            "default_value":null,
-                           "description":"Maximum number of gears having cartridge mongodb-2.2",
+                           "description":"Maximum number of gears having cartridge mongodb-2.4",
                            "name":"scales_to",
                            "type":"integer",
                            "valid_options":[
@@ -1206,7 +1206,7 @@
                      ]
                   },
                   "START":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1227,7 +1227,7 @@
                      ]
                   },
                   "STOP":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1248,7 +1248,7 @@
                      ]
                   },
                   "RESTART":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1269,7 +1269,7 @@
                      ]
                   },
                   "RELOAD":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1290,7 +1290,7 @@
                      ]
                   },
                   "DELETE":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                      "method":"DELETE",
                      "optional_params":[
 
@@ -1301,7 +1301,7 @@
                      ]
                   }
                },
-               "name":"mongodb-2.2",
+               "name":"mongodb-2.4",
                "properties":[
                   {
                      "name":"username",
@@ -1352,7 +1352,7 @@
          "creation_time":"2013-09-20T21:28:53Z",
          "domain_id":"foobarz",
          "embedded":{
-            "mongodb-2.2":{
+            "mongodb-2.4":{
                "connection_url":"mongodb://$OPENSHIFT_MONGODB_DB_HOST:$OPENSHIFT_MONGODB_DB_PORT/",
                "username":"admin",
                "password":"VwFPWQEs1PEl",
@@ -1675,7 +1675,7 @@
                      "type":"string",
                      "valid_options":[
                         "jbosseap-6",
-                        "mongodb-2.2"
+                        "mongodb-2.4"
                      ]
                   },
                   {
@@ -1718,7 +1718,7 @@
                "rel":"Add embedded cartridge",
                "required_params":[
                   {
-                     "description":"framework-type, e.g.: mongodb-2.2",
+                     "description":"framework-type, e.g.: mongodb-2.4",
                      "invalid_options":[
 
                      ],
@@ -1735,7 +1735,7 @@
                         "haproxy-1.4",
                         "postgresql-9.2",
                         "postgresql-8.4",
-                        "mongodb-2.2",
+                        "mongodb-2.4",
                         "jenkins-client-1"
                      ]
                   }

--- a/src/test/resources/samples/get-domains-foobarz-applications_2embedded.json
+++ b/src/test/resources/samples/get-domains-foobarz-applications_2embedded.json
@@ -793,7 +793,7 @@
                "rel":"Add embedded cartridge",
                "required_params":[
                   {
-                     "description":"framework-type, e.g.: mongodb-2.2",
+                     "description":"framework-type, e.g.: mongodb-2.4",
                      "invalid_options":[
 
                      ],
@@ -810,7 +810,7 @@
                         "haproxy-1.4",
                         "postgresql-9.2",
                         "postgresql-8.4",
-                        "mongodb-2.2",
+                        "mongodb-2.4",
                         "jenkins-client-1"
                      ]
                   }
@@ -905,7 +905,7 @@
                "additional_gear_storage":0,
                "base_gear_storage":1,
                "collocated_with":[
-                  "mongodb-2.2",
+                  "mongodb-2.4",
                   "mysql-5.1"
                ],
                "current_scale":1,
@@ -1160,7 +1160,7 @@
                "license_url":"",
                "links":{
                   "GET":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                      "method":"GET",
                      "optional_params":[
 
@@ -1171,12 +1171,12 @@
                      ]
                   },
                   "UPDATE":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                      "method":"PUT",
                      "optional_params":[
                         {
                            "default_value":null,
-                           "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.2",
+                           "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.4",
                            "name":"additional_gear_storage",
                            "type":"integer",
                            "valid_options":[
@@ -1185,7 +1185,7 @@
                         },
                         {
                            "default_value":null,
-                           "description":"Minimum number of gears having cartridge mongodb-2.2",
+                           "description":"Minimum number of gears having cartridge mongodb-2.4",
                            "name":"scales_from",
                            "type":"integer",
                            "valid_options":[
@@ -1194,7 +1194,7 @@
                         },
                         {
                            "default_value":null,
-                           "description":"Maximum number of gears having cartridge mongodb-2.2",
+                           "description":"Maximum number of gears having cartridge mongodb-2.4",
                            "name":"scales_to",
                            "type":"integer",
                            "valid_options":[
@@ -1208,7 +1208,7 @@
                      ]
                   },
                   "START":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1229,7 +1229,7 @@
                      ]
                   },
                   "STOP":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1250,7 +1250,7 @@
                      ]
                   },
                   "RESTART":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1271,7 +1271,7 @@
                      ]
                   },
                   "RELOAD":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1292,7 +1292,7 @@
                      ]
                   },
                   "DELETE":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                      "method":"DELETE",
                      "optional_params":[
 
@@ -1303,7 +1303,7 @@
                      ]
                   }
                },
-               "name":"mongodb-2.2",
+               "name":"mongodb-2.4",
                "properties":[
                   {
                      "name":"username",
@@ -1355,7 +1355,7 @@
                "base_gear_storage":1,
                "collocated_with":[
                   "jbosseap-6",
-                  "mongodb-2.2"
+                  "mongodb-2.4"
                ],
                "current_scale":1,
                "description":"MySQL is a multi-user, multi-threaded SQL database server.",
@@ -1561,7 +1561,7 @@
          "creation_time":"2013-09-20T21:28:53Z",
          "domain_id":"foobarz",
          "embedded":{
-            "mongodb-2.2":{
+            "mongodb-2.4":{
                "connection_url":"mongodb://$OPENSHIFT_MONGODB_DB_HOST:$OPENSHIFT_MONGODB_DB_PORT/",
                "username":"admin",
                "password":"VwFPWQEs1PEl",
@@ -1891,7 +1891,7 @@
                      "type":"string",
                      "valid_options":[
                         "jbosseap-6",
-                        "mongodb-2.2",
+                        "mongodb-2.4",
                         "mysql-5.1"
                      ]
                   },
@@ -1935,7 +1935,7 @@
                "rel":"Add embedded cartridge",
                "required_params":[
                   {
-                     "description":"framework-type, e.g.: mongodb-2.2",
+                     "description":"framework-type, e.g.: mongodb-2.4",
                      "invalid_options":[
 
                      ],
@@ -1952,7 +1952,7 @@
                         "haproxy-1.4",
                         "postgresql-9.2",
                         "postgresql-8.4",
-                        "mongodb-2.2",
+                        "mongodb-2.4",
                         "jenkins-client-1"
                      ]
                   }

--- a/src/test/resources/samples/get-domains-foobarz-applications_3embedded.json
+++ b/src/test/resources/samples/get-domains-foobarz-applications_3embedded.json
@@ -793,7 +793,7 @@
                "rel":"Add embedded cartridge",
                "required_params":[
                   {
-                     "description":"framework-type, e.g.: mongodb-2.2",
+                     "description":"framework-type, e.g.: mongodb-2.4",
                      "invalid_options":[
 
                      ],
@@ -810,7 +810,7 @@
                         "haproxy-1.4",
                         "postgresql-9.2",
                         "postgresql-8.4",
-                        "mongodb-2.2",
+                        "mongodb-2.4",
                         "jenkins-client-1"
                      ]
                   }
@@ -905,7 +905,7 @@
                "additional_gear_storage":0,
                "base_gear_storage":1,
                "collocated_with":[
-                  "mongodb-2.2",
+                  "mongodb-2.4",
                   "mysql-5.1",
                   "switchyard-0"
                ],
@@ -1162,7 +1162,7 @@
                "license_url":"",
                "links":{
                   "GET":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                      "method":"GET",
                      "optional_params":[
 
@@ -1173,12 +1173,12 @@
                      ]
                   },
                   "UPDATE":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                      "method":"PUT",
                      "optional_params":[
                         {
                            "default_value":null,
-                           "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.2",
+                           "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.4",
                            "name":"additional_gear_storage",
                            "type":"integer",
                            "valid_options":[
@@ -1187,7 +1187,7 @@
                         },
                         {
                            "default_value":null,
-                           "description":"Minimum number of gears having cartridge mongodb-2.2",
+                           "description":"Minimum number of gears having cartridge mongodb-2.4",
                            "name":"scales_from",
                            "type":"integer",
                            "valid_options":[
@@ -1196,7 +1196,7 @@
                         },
                         {
                            "default_value":null,
-                           "description":"Maximum number of gears having cartridge mongodb-2.2",
+                           "description":"Maximum number of gears having cartridge mongodb-2.4",
                            "name":"scales_to",
                            "type":"integer",
                            "valid_options":[
@@ -1210,7 +1210,7 @@
                      ]
                   },
                   "START":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1231,7 +1231,7 @@
                      ]
                   },
                   "STOP":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1252,7 +1252,7 @@
                      ]
                   },
                   "RESTART":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1273,7 +1273,7 @@
                      ]
                   },
                   "RELOAD":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1294,7 +1294,7 @@
                      ]
                   },
                   "DELETE":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                      "method":"DELETE",
                      "optional_params":[
 
@@ -1305,7 +1305,7 @@
                      ]
                   }
                },
-               "name":"mongodb-2.2",
+               "name":"mongodb-2.4",
                "properties":[
                   {
                      "name":"username",
@@ -1357,7 +1357,7 @@
                "base_gear_storage":1,
                "collocated_with":[
                   "jbosseap-6",
-                  "mongodb-2.2",
+                  "mongodb-2.4",
                   "switchyard-0"
                ],
                "current_scale":1,
@@ -1565,7 +1565,7 @@
                "base_gear_storage":1,
                "collocated_with":[
                   "jbosseap-6",
-                  "mongodb-2.2",
+                  "mongodb-2.4",
                   "mysql-5.1"
                ],
                "current_scale":1,
@@ -1746,7 +1746,7 @@
          "creation_time":"2013-09-20T21:28:53Z",
          "domain_id":"foobarz",
          "embedded":{
-            "mongodb-2.2":{
+            "mongodb-2.4":{
                "connection_url":"mongodb://$OPENSHIFT_MONGODB_DB_HOST:$OPENSHIFT_MONGODB_DB_PORT/",
                "username":"admin",
                "password":"VwFPWQEs1PEl",
@@ -2079,7 +2079,7 @@
                      "type":"string",
                      "valid_options":[
                         "jbosseap-6",
-                        "mongodb-2.2",
+                        "mongodb-2.4",
                         "mysql-5.1",
                         "switchyard-0"
                      ]
@@ -2124,7 +2124,7 @@
                "rel":"Add embedded cartridge",
                "required_params":[
                   {
-                     "description":"framework-type, e.g.: mongodb-2.2",
+                     "description":"framework-type, e.g.: mongodb-2.4",
                      "invalid_options":[
 
                      ],
@@ -2141,7 +2141,7 @@
                         "haproxy-1.4",
                         "postgresql-9.2",
                         "postgresql-8.4",
-                        "mongodb-2.2",
+                        "mongodb-2.4",
                         "jenkins-client-1"
                      ]
                   }

--- a/src/test/resources/samples/get-domains-foobarz-applications_noenvvars.json
+++ b/src/test/resources/samples/get-domains-foobarz-applications_noenvvars.json
@@ -784,7 +784,7 @@
                "rel":"Add embedded cartridge",
                "required_params":[
                   {
-                     "description":"framework-type, e.g.: mongodb-2.2",
+                     "description":"framework-type, e.g.: mongodb-2.4",
                      "invalid_options":[
 
                      ],
@@ -801,7 +801,7 @@
                         "haproxy-1.4",
                         "postgresql-9.2",
                         "postgresql-8.4",
-                        "mongodb-2.2",
+                        "mongodb-2.4",
                         "jenkins-client-1"
                      ]
                   }
@@ -848,7 +848,7 @@
                "additional_gear_storage":0,
                "base_gear_storage":1,
                "collocated_with":[
-                  "mongodb-2.2"
+                  "mongodb-2.4"
                ],
                "current_scale":1,
                "description":"Market-leading open source enterprise platform for next-generation, highly transactional enterprise Java applications. Build and deploy enterprise Java in the cloud.",
@@ -1101,7 +1101,7 @@
                "license_url":"",
                "links":{
                   "GET":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                      "method":"GET",
                      "optional_params":[
 
@@ -1112,12 +1112,12 @@
                      ]
                   },
                   "UPDATE":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                      "method":"PUT",
                      "optional_params":[
                         {
                            "default_value":null,
-                           "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.2",
+                           "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.4",
                            "name":"additional_gear_storage",
                            "type":"integer",
                            "valid_options":[
@@ -1126,7 +1126,7 @@
                         },
                         {
                            "default_value":null,
-                           "description":"Minimum number of gears having cartridge mongodb-2.2",
+                           "description":"Minimum number of gears having cartridge mongodb-2.4",
                            "name":"scales_from",
                            "type":"integer",
                            "valid_options":[
@@ -1135,7 +1135,7 @@
                         },
                         {
                            "default_value":null,
-                           "description":"Maximum number of gears having cartridge mongodb-2.2",
+                           "description":"Maximum number of gears having cartridge mongodb-2.4",
                            "name":"scales_to",
                            "type":"integer",
                            "valid_options":[
@@ -1149,7 +1149,7 @@
                      ]
                   },
                   "START":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1170,7 +1170,7 @@
                      ]
                   },
                   "STOP":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1191,7 +1191,7 @@
                      ]
                   },
                   "RESTART":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1212,7 +1212,7 @@
                      ]
                   },
                   "RELOAD":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1233,7 +1233,7 @@
                      ]
                   },
                   "DELETE":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                      "method":"DELETE",
                      "optional_params":[
 
@@ -1244,7 +1244,7 @@
                      ]
                   }
                },
-               "name":"mongodb-2.2",
+               "name":"mongodb-2.4",
                "properties":[
                   {
                      "name":"username",
@@ -1295,7 +1295,7 @@
          "creation_time":"2013-09-20T21:28:53Z",
          "domain_id":"foobarz",
          "embedded":{
-            "mongodb-2.2":{
+            "mongodb-2.4":{
                "connection_url":"mongodb://$OPENSHIFT_MONGODB_DB_HOST:$OPENSHIFT_MONGODB_DB_PORT/",
                "username":"admin",
                "password":"VwFPWQEs1PEl",
@@ -1618,7 +1618,7 @@
                      "type":"string",
                      "valid_options":[
                         "jbosseap-6",
-                        "mongodb-2.2"
+                        "mongodb-2.4"
                      ]
                   },
                   {
@@ -1652,7 +1652,7 @@
                "rel":"Add embedded cartridge",
                "required_params":[
                   {
-                     "description":"framework-type, e.g.: mongodb-2.2",
+                     "description":"framework-type, e.g.: mongodb-2.4",
                      "invalid_options":[
 
                      ],
@@ -1669,7 +1669,7 @@
                         "haproxy-1.4",
                         "postgresql-9.2",
                         "postgresql-8.4",
-                        "mongodb-2.2",
+                        "mongodb-2.4",
                         "jenkins-client-1"
                      ]
                   }

--- a/src/test/resources/samples/get-domains-foobarz-applications_springeap_scalable_downloadablecart.json
+++ b/src/test/resources/samples/get-domains-foobarz-applications_springeap_scalable_downloadablecart.json
@@ -793,7 +793,7 @@
                "rel":"Add embedded cartridge",
                "required_params":[
                   {
-                     "description":"framework-type, e.g.: mongodb-2.2",
+                     "description":"framework-type, e.g.: mongodb-2.4",
                      "invalid_options":[
 
                      ],
@@ -810,7 +810,7 @@
                         "haproxy-1.4",
                         "postgresql-9.2",
                         "postgresql-8.4",
-                        "mongodb-2.2",
+                        "mongodb-2.4",
                         "jenkins-client-1"
                      ]
                   }
@@ -905,7 +905,7 @@
                "additional_gear_storage":0,
                "base_gear_storage":1,
                "collocated_with":[
-                  "mongodb-2.2",
+                  "mongodb-2.4",
                   "mysql-5.1",
                   "switchyard-0"
                ],
@@ -1162,7 +1162,7 @@
                "license_url":"",
                "links":{
                   "GET":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                      "method":"GET",
                      "optional_params":[
 
@@ -1173,12 +1173,12 @@
                      ]
                   },
                   "UPDATE":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                      "method":"PUT",
                      "optional_params":[
                         {
                            "default_value":null,
-                           "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.2",
+                           "description":"Additional filesystem storage in gigabytes on each gear having cartridge mongodb-2.4",
                            "name":"additional_gear_storage",
                            "type":"integer",
                            "valid_options":[
@@ -1187,7 +1187,7 @@
                         },
                         {
                            "default_value":null,
-                           "description":"Minimum number of gears having cartridge mongodb-2.2",
+                           "description":"Minimum number of gears having cartridge mongodb-2.4",
                            "name":"scales_from",
                            "type":"integer",
                            "valid_options":[
@@ -1196,7 +1196,7 @@
                         },
                         {
                            "default_value":null,
-                           "description":"Maximum number of gears having cartridge mongodb-2.2",
+                           "description":"Maximum number of gears having cartridge mongodb-2.4",
                            "name":"scales_to",
                            "type":"integer",
                            "valid_options":[
@@ -1210,7 +1210,7 @@
                      ]
                   },
                   "START":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1231,7 +1231,7 @@
                      ]
                   },
                   "STOP":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1252,7 +1252,7 @@
                      ]
                   },
                   "RESTART":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1273,7 +1273,7 @@
                      ]
                   },
                   "RELOAD":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2/events",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4/events",
                      "method":"POST",
                      "optional_params":[
 
@@ -1294,7 +1294,7 @@
                      ]
                   },
                   "DELETE":{
-                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.2",
+                     "href":"https://openshift.redhat.com/broker/rest/domains/foobarz/applications/springeap6/cartridges/mongodb-2.4",
                      "method":"DELETE",
                      "optional_params":[
 
@@ -1305,7 +1305,7 @@
                      ]
                   }
                },
-               "name":"mongodb-2.2",
+               "name":"mongodb-2.4",
                "properties":[
                   {
                      "name":"username",
@@ -1357,7 +1357,7 @@
                "base_gear_storage":1,
                "collocated_with":[
                   "jbosseap-6",
-                  "mongodb-2.2",
+                  "mongodb-2.4",
                   "switchyard-0"
                ],
                "current_scale":1,
@@ -1565,7 +1565,7 @@
                "base_gear_storage":1,
                "collocated_with":[
                   "jbosseap-6",
-                  "mongodb-2.2",
+                  "mongodb-2.4",
                   "mysql-5.1"
                ],
                "current_scale":1,
@@ -1751,7 +1751,7 @@
          "creation_time":"2013-09-20T21:28:53Z",
          "domain_id":"foobarz",
          "embedded":{
-            "mongodb-2.2":{
+            "mongodb-2.4":{
                "connection_url":"mongodb://$OPENSHIFT_MONGODB_DB_HOST:$OPENSHIFT_MONGODB_DB_PORT/",
                "username":"admin",
                "password":"VwFPWQEs1PEl",
@@ -2084,7 +2084,7 @@
                      "type":"string",
                      "valid_options":[
                         "jbosseap-6",
-                        "mongodb-2.2",
+                        "mongodb-2.4",
                         "mysql-5.1",
                         "switchyard-0"
                      ]
@@ -2129,7 +2129,7 @@
                "rel":"Add embedded cartridge",
                "required_params":[
                   {
-                     "description":"framework-type, e.g.: mongodb-2.2",
+                     "description":"framework-type, e.g.: mongodb-2.4",
                      "invalid_options":[
 
                      ],
@@ -2146,7 +2146,7 @@
                         "haproxy-1.4",
                         "postgresql-9.2",
                         "postgresql-8.4",
-                        "mongodb-2.2",
+                        "mongodb-2.4",
                         "jenkins-client-1"
                      ]
                   }
@@ -3184,7 +3184,7 @@
                "rel":"Add embedded cartridge",
                "required_params":[
                   {
-                     "description":"framework-type, e.g.: mongodb-2.2",
+                     "description":"framework-type, e.g.: mongodb-2.4",
                      "invalid_options":[
 
                      ],
@@ -3201,7 +3201,7 @@
                         "haproxy-1.4",
                         "postgresql-9.2",
                         "postgresql-8.4",
-                        "mongodb-2.2",
+                        "mongodb-2.4",
                         "jenkins-client-1",
                         "andygoldstein-foreman-0.63.0"
                      ]

--- a/src/test/resources/samples/get-domains-foobarz.json
+++ b/src/test/resources/samples/get-domains-foobarz.json
@@ -30,7 +30,7 @@
             "optional_params":[
                {
                   "default_value":null,
-                  "description":"Array of one or more cartridge names. i.e. [\"php-5.3\", \"mongodb-2.2\"]",
+                  "description":"Array of one or more cartridge names. i.e. [\"php-5.3\", \"mongodb-2.4\"]",
                   "name":"cartridges",
                   "type":"array",
                   "valid_options":[

--- a/src/test/resources/samples/get-domains.json
+++ b/src/test/resources/samples/get-domains.json
@@ -31,7 +31,7 @@
                "optional_params":[
                   {
                      "default_value":null,
-                     "description":"Array of one or more cartridge names. i.e. [\"php-5.3\", \"mongodb-2.2\"]",
+                     "description":"Array of one or more cartridge names. i.e. [\"php-5.3\", \"mongodb-2.4\"]",
                      "name":"cartridges",
                      "type":"array",
                      "valid_options":[
@@ -277,7 +277,7 @@
     	        "optional_params": [
     	          {
     	            "default_value": null,
-    	            "description": "Array of one or more cartridge names. i.e. [\"php-5.3\", \"mongodb-2.2\"]",
+    	            "description": "Array of one or more cartridge names. i.e. [\"php-5.3\", \"mongodb-2.4\"]",
     	            "name": "cartridges",
     	            "type": "array",
     	            "valid_options": [

--- a/src/test/resources/samples/post-jekyll-domains-foobarz-applications.json
+++ b/src/test/resources/samples/post-jekyll-domains-foobarz-applications.json
@@ -373,7 +373,7 @@
                      "haproxy-1.4",
                      "jenkins-client-1.4",
                      "metrics-0.1",
-                     "mongodb-2.2",
+                     "mongodb-2.4",
                      "mysql-5.1",
                      "phpmyadmin-3.4",
                      "postgresql-8.4",

--- a/src/test/resources/samples/post-mysql-domains-foobarz-applications-springeap6-cartridges.json
+++ b/src/test/resources/samples/post-mysql-domains-foobarz-applications-springeap6-cartridges.json
@@ -4,7 +4,7 @@
       "base_gear_storage":1,
       "collocated_with":[
          "jbosseap-6",
-         "mongodb-2.2"
+         "mongodb-2.4"
       ],
       "current_scale":1,
       "description":"MySQL is a multi-user, multi-threaded SQL database server.",

--- a/src/test/resources/samples/post-scalable-domains-foobarz-applications.json
+++ b/src/test/resources/samples/post-scalable-domains-foobarz-applications.json
@@ -367,7 +367,7 @@
                   "name":"name",
                   "type":"string",
                   "valid_options":[
-                     "mongodb-2.2",
+                     "mongodb-2.4",
                      "switchyard-0.6",
                      "cron-1.4",
                      "mysql-5.1",

--- a/src/test/resources/samples/post-stop-domains-foobarz-applications-springeap6-events.json
+++ b/src/test/resources/samples/post-stop-domains-foobarz-applications-springeap6-events.json
@@ -147,7 +147,7 @@
       "creation_time":"2013-04-30T17:00:41Z",
       "domain_id":"foobarz",
       "embedded":{
-         "mongodb-2.2":{
+         "mongodb-2.4":{
             "connection_url":"mongodb://$OPENSHIFT_MONGODB_DB_HOST:$OPENSHIFT_MONGODB_DB_PORT/",
             "username":"admin",
             "password":"NNxXMT1z8dVj",
@@ -413,7 +413,7 @@
                   "type":"string",
                   "valid_options":[
                      "jbosseap-6",
-                     "mongodb-2.2",
+                     "mongodb-2.4",
                      "mysql-5.1"
                   ]
                },
@@ -455,7 +455,7 @@
                   "name":"name",
                   "type":"string",
                   "valid_options":[
-                     "mongodb-2.2",
+                     "mongodb-2.4",
                      "switchyard-0.6",
                      "cron-1.4",
                      "mysql-5.1",


### PR DESCRIPTION
MongoDB version update from 2.2 to 2.4

This PR depends on PRs from other openshift repositories, and should be merged together with them.

PRs:
- li repo : https://github.com/openshift/li/pull/2313
- origin-server repo : https://github.com/openshift/origin-server/pull/4602
- rhc repo : https://github.com/openshift/rhc/pull/539
