### PR TITLE
[OSJC 61-66-71] fixing where timeouts are read from

### DIFF
--- a/src/main/java/com/openshift/client/IHttpClient.java
+++ b/src/main/java/com/openshift/client/IHttpClient.java
@@ -24,6 +24,7 @@ import com.openshift.internal.client.httpclient.request.Parameter;
 /**
  * @author André Dietisheim
  * @author Nicolas Spano
+ * @author Corey Daley
  */
 public interface IHttpClient {
 	
@@ -65,9 +66,8 @@ public interface IHttpClient {
 	public static final String SYSPROP_DEFAULT_CONNECT_TIMEOUT = "sun.net.client.defaultConnectTimeout";
 	public static final String SYSPROP_DEFAULT_READ_TIMEOUT = "sun.net.client.defaultReadTimeout";
 
-    public static final int DEFAULT_CONNECT_TIMEOUT = 10 * 	1000;
     public static final int DEFAULT_READ_TIMEOUT = 2 * 60 * 1000;
-	public static final int NO_TIMEOUT = 0;
+	public static final int NO_TIMEOUT = -1;
 
 	public String get(URL url, int timeout) throws HttpClientException, SocketTimeoutException;
 

--- a/src/main/java/com/openshift/client/OpenShiftConnectionFactory.java
+++ b/src/main/java/com/openshift/client/OpenShiftConnectionFactory.java
@@ -29,10 +29,11 @@ import com.openshift.internal.client.utils.Assert;
  * 
  * @author Xavier Coulon
  * @author Andre Dietisheim
+ * @author Corey Daley
  * 
  */
 public class OpenShiftConnectionFactory extends AbstractOpenShiftConnectionFactory {
-
+	private IOpenShiftConfiguration configuration = null;
 	/**
 	 * Establish a connection with the clientId along with user's password.
 	 * User's login and Server URL are retrieved from the local configuration
@@ -48,7 +49,6 @@ public class OpenShiftConnectionFactory extends AbstractOpenShiftConnectionFacto
 	 * @throws OpenShiftException
 	 */
 	public IOpenShiftConnection getConnection(final String clientId, final String password) throws OpenShiftException {
-		IOpenShiftConfiguration configuration = null;
 		try {
 			configuration = new OpenShiftConfiguration();
 		} catch (IOException e) {
@@ -75,7 +75,6 @@ public class OpenShiftConnectionFactory extends AbstractOpenShiftConnectionFacto
 	 */
 	public IOpenShiftConnection getConnection(final String clientId, final String username, final String password)
 			throws OpenShiftException {
-		IOpenShiftConfiguration configuration;
 		try {
 			configuration = new OpenShiftConfiguration();
 		} catch (IOException e) {
@@ -134,8 +133,16 @@ public class OpenShiftConnectionFactory extends AbstractOpenShiftConnectionFacto
 	 * @throws OpenShiftException
 	 */
 	public IOpenShiftConnection getConnection(final String clientId, final String username, final String password,
-			final String authKey, final String authIV, final String serverUrl,
-			final ISSLCertificateCallback sslCertificateCallback) throws OpenShiftException {
+		final String authKey, final String authIV, final String serverUrl,
+		final ISSLCertificateCallback sslCertificateCallback) throws OpenShiftException {
+		if (configuration == null) {
+			try {
+				configuration = new OpenShiftConfiguration();
+			} catch (IOException e) {
+				throw new OpenShiftException(e, "Failed to load OpenShift configuration file.");
+			}
+		}
+
 		Assert.notNull(clientId);
 		Assert.notNull(username);
 		Assert.notNull(password);
@@ -146,6 +153,7 @@ public class OpenShiftConnectionFactory extends AbstractOpenShiftConnectionFacto
 					new UrlConnectionHttpClientBuilder()
 						.setCredentials(username, password, authKey, authIV)
 						.setSSLCertificateCallback(sslCertificateCallback)
+						.setConfigTimeout(configuration.getTimeout())
 						.client();
 			return getConnection(clientId, username, password, serverUrl, httpClient);
 		} catch (IOException e) {

--- a/src/main/java/com/openshift/client/configuration/AbstractOpenshiftConfiguration.java
+++ b/src/main/java/com/openshift/client/configuration/AbstractOpenshiftConfiguration.java
@@ -25,6 +25,7 @@ import com.openshift.internal.client.utils.UrlUtils;
 
 /**
  * @author André Dietisheim
+ * @author Corey Daley
  */
 public abstract class AbstractOpenshiftConfiguration implements IOpenShiftConfiguration {
 
@@ -32,9 +33,12 @@ public abstract class AbstractOpenshiftConfiguration implements IOpenShiftConfig
 	protected static final String KEY_LIBRA_SERVER = "libra_server";
 	protected static final String KEY_LIBRA_DOMAIN = "libra_domain";
 
+
 	protected static final String KEY_PASSWORD = "rhpassword";
 	protected static final String KEY_CLIENT_ID = "client_id";
-	
+
+	protected static final String KEY_TIMEOUT = "timeout";
+
 	private static final Pattern QUOTED_REGEX = Pattern.compile("['\"]*([^'\"]+)['\"]*");
 	private static final char SINGLEQUOTE = '\'';
 		
@@ -137,6 +141,10 @@ public abstract class AbstractOpenshiftConfiguration implements IOpenShiftConfig
 
 	public String getLibraDomain() {
 		return removeQuotes(properties.getProperty(KEY_LIBRA_DOMAIN));
+	}
+
+	public Integer getTimeout() {
+		return Integer.parseInt(properties.getProperty(KEY_TIMEOUT));
 	}
 
 	protected String ensureIsSingleQuoted(String value) {

--- a/src/main/java/com/openshift/client/configuration/DefaultConfiguration.java
+++ b/src/main/java/com/openshift/client/configuration/DefaultConfiguration.java
@@ -14,10 +14,12 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
 
+import com.openshift.client.IHttpClient;
 import com.openshift.client.OpenShiftException;
 
 /**
  * @author André Dietisheim
+ * @author Corey Daley
  */
 public class DefaultConfiguration extends AbstractOpenshiftConfiguration {
 
@@ -33,6 +35,7 @@ public class DefaultConfiguration extends AbstractOpenshiftConfiguration {
 		Properties properties = new Properties();
 	    properties.put(KEY_LIBRA_SERVER, LIBRA_SERVER);
 	    properties.put(KEY_LIBRA_DOMAIN, LIBRA_DOMAIN);
+		properties.put(KEY_TIMEOUT, "180000");
 		return properties;
 	}
 }

--- a/src/main/java/com/openshift/client/configuration/IOpenShiftConfiguration.java
+++ b/src/main/java/com/openshift/client/configuration/IOpenShiftConfiguration.java
@@ -14,6 +14,7 @@ import java.util.Properties;
 
 /**
  * @author André Dietisheim
+ * @author Corey Daley
  */
 public interface IOpenShiftConfiguration {
 
@@ -26,6 +27,8 @@ public interface IOpenShiftConfiguration {
 	public abstract void setLibraServer(String libraServer);
 
 	public abstract String getLibraDomain();
+
+	public Integer getTimeout();
 
 	public abstract void setLibraDomain(String libraDomain);
 

--- a/src/main/java/com/openshift/client/configuration/SystemProperties.java
+++ b/src/main/java/com/openshift/client/configuration/SystemProperties.java
@@ -18,9 +18,12 @@ import com.openshift.client.OpenShiftException;
 
 /**
  * @author André Dietisheim
+ * @author Corey Daley
  */
 public class SystemProperties extends AbstractOpenshiftConfiguration {
 
+	protected static final String KEY_OPENSHIFT_TIMEOUT = "express.timeout";
+	
 	public SystemProperties(IOpenShiftConfiguration parentConfiguration) throws OpenShiftException, IOException {
 		super(parentConfiguration);
 	}
@@ -33,12 +36,15 @@ public class SystemProperties extends AbstractOpenshiftConfiguration {
 		copySystemProperty(KEY_RHLOGIN, properties);
 		copySystemProperty(KEY_PASSWORD, properties);
 		copySystemProperty(KEY_CLIENT_ID, properties);
+		copySystemProperty(KEY_OPENSHIFT_TIMEOUT, properties);
 		return properties;
 	}
 
 	private void copySystemProperty(String key, Properties properties) {
 		Object value = System.getProperties().get(key);
-		if (value != null) {
+		if (key.equals(KEY_OPENSHIFT_TIMEOUT) && value != null) {
+			properties.put(KEY_TIMEOUT, value);
+		} else if (value != null) {
 			properties.put(key, value);
 		}
 	}

--- a/src/main/java/com/openshift/internal/client/IRestService.java
+++ b/src/main/java/com/openshift/internal/client/IRestService.java
@@ -84,7 +84,6 @@ public interface IRestService {
 	 * @see IHttpClient#SYSPROP_DEFAULT_CONNECT_TIMEOUT
 	 * @see IHttpClient#SYSPROP_DEFAULT_READ_TIMEOUT
 	 * @see IHttpClient#SYSPROP_OPENSHIFT_CONNECT_TIMEOUT
-	 * @see IHttpClient#DEFAULT_CONNECT_TIMEOUT
 	 * @see IHttpClient#DEFAULT_READ_TIMEOUT
 	 */
 	public RestResponse request(Link link, int timeout, IMediaType mediaType, List<Parameter> urlPathParameters,

--- a/src/main/java/com/openshift/internal/client/httpclient/UrlConnectionHttpClientBuilder.java
+++ b/src/main/java/com/openshift/internal/client/httpclient/UrlConnectionHttpClientBuilder.java
@@ -15,6 +15,7 @@ import com.openshift.client.IHttpClient.ISSLCertificateCallback;
 
 /**
  * @author André Dietisheim
+ * @author Corey Daley
  */
 public class UrlConnectionHttpClientBuilder {
 
@@ -25,6 +26,7 @@ public class UrlConnectionHttpClientBuilder {
 	private String authIV;
 	private String acceptedMediaType;
 	private String version;
+	private Integer configTimeout;
 	private ISSLCertificateCallback callback;
 
 	public UrlConnectionHttpClientBuilder setUserAgent(String userAgent) {
@@ -41,6 +43,10 @@ public class UrlConnectionHttpClientBuilder {
 		this.password = password;
 		this.authKey = authKey;
 		this.authIV = authIV;
+		return this;
+	}
+	public UrlConnectionHttpClientBuilder setConfigTimeout (Integer configTimeout) {
+		this.configTimeout = configTimeout;
 		return this;
 	}
 
@@ -61,6 +67,6 @@ public class UrlConnectionHttpClientBuilder {
 
 	public IHttpClient client() {
 		return new UrlConnectionHttpClient(
-				username, password, userAgent, acceptedMediaType, version, authKey, authIV, callback);
+				username, password, userAgent, acceptedMediaType, version, authKey, authIV, callback, configTimeout);
 	}
 }

--- a/src/test/java/com/openshift/client/fakes/OpenShiftConfigurationFake.java
+++ b/src/test/java/com/openshift/client/fakes/OpenShiftConfigurationFake.java
@@ -1,0 +1,46 @@
+package com.openshift.client.fakes;
+
+import com.openshift.client.OpenShiftException;
+import com.openshift.client.configuration.*;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Properties;
+
+/**
+ * @author Corey Daley
+ */
+public class OpenShiftConfigurationFake extends AbstractOpenshiftConfiguration {
+	public OpenShiftConfigurationFake(final String systemConfigurationTimeout, final String userConfigurationTimeout, final String systemPropertiesTimeout) throws FileNotFoundException, IOException, OpenShiftException {
+		super(new SystemPropertiesFake(
+				new UserConfigurationFake(
+						new SystemConfigurationFake(
+								new DefaultConfiguration()){
+							//SystemConfigurationFake
+							protected void init(Properties properties) {
+								if (systemConfigurationTimeout != null) {
+									properties.put(KEY_TIMEOUT, systemConfigurationTimeout);
+								}
+							}
+						}){
+					//UserConfigurationFake
+					protected void initFile(Writer writer) throws IOException {
+						if (userConfigurationTimeout != null) {
+							writer.append(KEY_TIMEOUT).append('=').append(userConfigurationTimeout).append('\n');
+						}
+					}
+				}){
+			//SystemPropertiesFake
+			@Override
+			protected Properties getProperties(File file, Properties defaultProperties) {
+				Properties properties = new Properties(defaultProperties);
+				if (systemPropertiesTimeout != null) {
+					properties.setProperty(KEY_TIMEOUT,systemPropertiesTimeout);
+				}
+				return properties;
+			}
+		});
+	}
+}

--- a/src/test/java/com/openshift/client/fakes/PayLoadReturningHttpClientFake.java
+++ b/src/test/java/com/openshift/client/fakes/PayLoadReturningHttpClientFake.java
@@ -44,6 +44,7 @@ public class PayLoadReturningHttpClientFake extends UrlConnectionHttpClient {
 				version,
 				null,
 				null,
+				null,
 				null);
 	}
 

--- a/src/test/java/com/openshift/client/fakes/SystemPropertiesFake.java
+++ b/src/test/java/com/openshift/client/fakes/SystemPropertiesFake.java
@@ -1,0 +1,16 @@
+package com.openshift.client.fakes;
+
+import com.openshift.client.OpenShiftException;
+import com.openshift.client.configuration.IOpenShiftConfiguration;
+import com.openshift.client.configuration.SystemProperties;
+
+import java.io.IOException;
+
+/**
+ * @author Corey Daley
+ */
+public class SystemPropertiesFake extends SystemProperties {
+	public SystemPropertiesFake(IOpenShiftConfiguration parentConfiguration) throws OpenShiftException, IOException {
+		super(parentConfiguration);
+	}
+}

--- a/src/test/java/com/openshift/client/utils/OpenShiftTestConfiguration.java
+++ b/src/test/java/com/openshift/client/utils/OpenShiftTestConfiguration.java
@@ -23,11 +23,15 @@ import com.openshift.client.configuration.IOpenShiftConfiguration;
 import com.openshift.client.configuration.SystemConfiguration;
 import com.openshift.client.configuration.SystemProperties;
 import com.openshift.client.configuration.UserConfiguration;
+import com.openshift.client.fakes.SystemConfigurationFake;
+import com.openshift.client.fakes.SystemPropertiesFake;
+import com.openshift.client.fakes.UserConfigurationFake;
 import com.openshift.internal.client.utils.StreamUtils;
 import com.openshift.internal.client.utils.StringUtils;
 
 /**
  * @author André Dietisheim
+ * @author Corey Daley
  */
 public class OpenShiftTestConfiguration extends AbstractOpenshiftConfiguration {
 
@@ -38,10 +42,10 @@ public class OpenShiftTestConfiguration extends AbstractOpenshiftConfiguration {
 	private static final String DEVSERVER_PREFIX = "https://ec2-";
 
 	public OpenShiftTestConfiguration() throws FileNotFoundException, IOException, OpenShiftException {
-		super(new SystemProperties(
+		super(new SystemPropertiesFake(
 				new IntegrationTestConfiguration(
-						new UserConfiguration(
-								new SystemConfiguration(
+						new UserConfigurationFake(
+								new SystemConfigurationFake(
 										new DefaultConfiguration())))));
 	}
 


### PR DESCRIPTION
Updated to have a default timeout of 3 minutes, which can be overridden by the system configuration (/etc/openshift/express.conf), which can be overridden by the user configuration (~/.openshift/express.conf), which can be overridden by system properties (-Dexpress.timeout=<integer>).  Also wrote associated tests to test overriding, and added a couple of more "fakes" that were needed for the tests.
