### PR TITLE
[OSJC-54] adding more detail to SSH Exception

### DIFF
--- a/src/main/java/com/openshift/client/IApplication.java
+++ b/src/main/java/com/openshift/client/IApplication.java
@@ -4,7 +4,7 @@
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
  * and is available at http://www.eclipse.org/legal/epl-v10.html 
- * 
+ *
  * Contributors: 
  * Red Hat, Inc. - initial API and implementation 
  ******************************************************************************/
@@ -32,14 +32,14 @@ public interface IApplication extends IOpenShiftResource {
 
 	/**
 	 * Returns the name of this application.
-	 * 
+	 *
 	 * @return
 	 */
 	public String getName();
 
 	/**
 	 * Returns the uuid of this application.
-	 * 
+	 *
 	 * @return the uuid of this application.
 	 */
 	public String getUUID();
@@ -47,28 +47,28 @@ public interface IApplication extends IOpenShiftResource {
 	/**
 	 * Returns the uri at which the git repository of this application may be
 	 * reached at.
-	 * 
+	 *
 	 * @return the uri of the git repo of this application.
 	 */
 	public String getGitUrl();
 
 	/**
 	 * Returns the url to use to connect with ssh.
-	 * 
+	 *
 	 * @return the url to use to connect with ssh.
 	 */
 	public String getSshUrl();
 
 	/**
 	 * Returns the git url that the application will get its initial code and configuration from.
-	 *  
+	 *
 	 * @return the initial git url
 	 */
 	public String getInitialGitUrl();
-	
+
 	/**
 	 * Returns the url at which this application may be reached at.
-	 * 
+	 *
 	 * @return the url of this application.
 	 */
 	public String getApplicationUrl();
@@ -76,7 +76,7 @@ public interface IApplication extends IOpenShiftResource {
 	/**
 	 * Returns true if scaling is enabled on this application (only set at
 	 * creation time).
-	 * 
+	 *
 	 * @return true if scaling is enabled on this application (only set at
 	 *         creation time).
 	 */
@@ -85,7 +85,7 @@ public interface IApplication extends IOpenShiftResource {
 	/**
 	 * Returns true if scaling is enabled on this application (only set at
 	 * creation time).
-	 * 
+	 *
 	 * @return true if scaling is enabled on this application (only set at
 	 *         creation time).
 	 */
@@ -93,15 +93,15 @@ public interface IApplication extends IOpenShiftResource {
 
 	/**
 	 * Returns the cartridge (application type) that this app is running on.
-	 * 
+	 *
 	 * @return the cartridge of this application
-	 * 
+	 *
 	 */
 	public IStandaloneCartridge getCartridge();
 
 	/**
 	 * Adds the given embeddable cartridge to this application.
-	 * 
+	 *
 	 * @param cartridge
 	 * @throws OpenShiftException
 	 */
@@ -109,10 +109,10 @@ public interface IApplication extends IOpenShiftResource {
 
 	/**
 	 * Adds all given embedded cartridges from this app, given their names.
-	 * 
+	 *
 	 * @param embeddedCartridges
 	 * @throws OpenShiftException
-	 * 
+	 *
 	 * @see #addEmbeddableCartridge(IEmbeddedCartridge)
 	 * @see #removeEmbeddedCartridge(IEmbeddedCartridge)
 	 */
@@ -121,10 +121,10 @@ public interface IApplication extends IOpenShiftResource {
 
 	/**
 	 * Returns all embedded cartridges.
-	 * 
+	 *
 	 * @return all embedded cartridges.
 	 * @throws OpenShiftException
-	 * 
+	 *
 	 * @see IEmbeddedCartridge
 	 * @see #addEmbeddableCartridge(IEmbeddedCartridge)
 	 * @see #removeEmbeddedCartridge(IEmbeddedCartridge)
@@ -134,12 +134,12 @@ public interface IApplication extends IOpenShiftResource {
 	/**
 	 * Returns <code>true</code> if this application has an embedded cartridge.
 	 * Returns <code>false</code> otherwise.
-	 * 
+	 *
 	 * @param the
 	 *            name of the cartridge to look for
 	 * @return true if there's an embedded cartridge with the given name
 	 * @throws OpenShiftException
-	 * 
+	 *
 	 * @see IEmbeddedCartridge
 	 * @see #addEmbeddableCartridge(IEmbeddedCartridge)
 	 * @see #removeEmbeddedCartridge(IEmbeddedCartridge)
@@ -149,12 +149,12 @@ public interface IApplication extends IOpenShiftResource {
 	/**
 	 * Returns <code>true</code> if this application has an embedded cartridge.
 	 * Returns <code>false</code> otherwise.
-	 * 
+	 *
 	 * @param the
 	 *            name of the cartridge to look for
 	 * @return true if there's an embedded cartridge with the given name
 	 * @throws OpenShiftException
-	 * 
+	 *
 	 * @see IEmbeddedCartridge
 	 * @see #addEmbeddableCartridge(IEmbeddedCartridge)
 	 * @see #removeEmbeddedCartridge(IEmbeddedCartridge)
@@ -164,7 +164,7 @@ public interface IApplication extends IOpenShiftResource {
 	/**
 	 * Returns the embedded cartridge given its name. Returns <code>null</code>
 	 * if none was found.
-	 * 
+	 *
 	 * @param cartridgeName
 	 * @return the embedded cartridge with the given name
 	 * @throws OpenShiftException
@@ -175,7 +175,7 @@ public interface IApplication extends IOpenShiftResource {
 	/**
 	 * Returns the embedded cartridge in this application. Returns <code>null</code> if none was
 	 * found.
-	 * 
+	 *
 	 * @param cartridge
 	 * @return the embedded cartridge
 	 * @throws OpenShiftException
@@ -188,7 +188,7 @@ public interface IApplication extends IOpenShiftResource {
 	 * Removes the given embedded cartridge that is equal to the given
 	 * embeddable cartridge. Does nothing if the cartridge is not present in
 	 * this application.
-	 * 
+	 *
 	 * @param cartridge
 	 *            the cartridge that shall be removed
 	 * @throws OpenShiftException
@@ -199,7 +199,7 @@ public interface IApplication extends IOpenShiftResource {
 	 * Removes the given embedded cartridges in this application that are equal to the
 	 * given IEmbeddableCartridge. Does nothing if the cartridge is not present
 	 * in this application.
-	 * 
+	 *
 	 * @param cartridges the cartridges that shall get removed
 	 * @throws OpenShiftException
 	 */
@@ -209,17 +209,17 @@ public interface IApplication extends IOpenShiftResource {
 	/**
 	 * Returns the gear groups for this application.
 	 * The collection is never cached, so each call will trigger a request to the OpenShift Broker.
-	 *  
+	 *
 	 * @return the collection of {@link IGearGroup} for this application.
 	 * @throws OpenShiftException
 	 */
 	public Collection<IGearGroup> getGearGroups() throws OpenShiftException;
-	
+
 	/**
 	 * Returns the timestamp at which this app was created.
-	 * 
+	 *
 	 * @return the creation time
-	 * 
+	 *
 	 * @throws OpenShiftException
 	 */
 	public Date getCreationTime();
@@ -227,51 +227,51 @@ public interface IApplication extends IOpenShiftResource {
 	/**
 	 * Destroys this application (and removes it from the list of available
 	 * applications)
-	 * 
+	 *
 	 * @throws OpenShiftException
-	 * 
+	 *
 	 * @see IUser#getApplications()
 	 */
 	public void destroy() throws OpenShiftException;
 
 	/**
 	 * Starts this application. Has no effect if this app is already running.
-	 * 
+	 *
 	 * @throws OpenShiftException
 	 */
 	public void start() throws OpenShiftException;
 
 	/**
 	 * Restarts this application.
-	 * 
+	 *
 	 * @throws OpenShiftException
 	 */
 	public void restart() throws OpenShiftException;
 
 	/**
 	 * Stops this application.
-	 * 
+	 *
 	 * @throws OpenShiftException
 	 */
 	public void stop() throws OpenShiftException;
 
 	/**
 	 * Stops this application
-	 * 
+	 *
 	 * @param force
 	 *            : true to force stop, false otherwise
-	 * 
+	 *
 	 * @throws OpenShiftException
 	 */
 	public void stop(boolean force) throws OpenShiftException;
 
 	/**
 	 * Waits for this application to become accessible on its public url.
-	 * 
+	 *
 	 * @param timeout
 	 * @return
 	 * @throws OpenShiftException
-	 * 
+	 *
 	 * @see IApplication#getApplicationUrl()
 	 */
 	public boolean waitForAccessible(long timeout) throws OpenShiftException;
@@ -279,11 +279,11 @@ public interface IApplication extends IOpenShiftResource {
 	/**
 	 * Returns a Future that the caller can use to wait for the application to
 	 * become accessible on its public url.
-	 * 
+	 *
 	 * @param timeout
 	 * @return
 	 * @throws OpenShiftException
-	 * 
+	 *
 	 * @see IApplication#getApplicationUrl()
 	 * @see IApplication#waitForAccessible(long)
 	 * @see IOpenShiftConnection#getExecutorService()
@@ -293,35 +293,35 @@ public interface IApplication extends IOpenShiftResource {
 
 	/**
 	 * Get the domain of the application.
-	 * 
+	 *
 	 * @return the domain
 	 */
 	public IDomain getDomain();
 
 	/**
 	 * Scale down application
-	 * 
+	 *
 	 * @throws OpenShiftException
 	 */
 	public void scaleDown() throws OpenShiftException;
 
 	/**
 	 * Scale up application
-	 * 
+	 *
 	 * @throws OpenShiftException
 	 */
 	public void scaleUp() throws OpenShiftException;
 
 	/**
 	 * Add application alias
-	 * 
+	 *
 	 * @throws OpenShiftException
 	 */
 	public void addAlias(String string) throws OpenShiftException;
 
 	/**
 	 * Retrieve all application aliases
-	 * 
+	 *
 	 * @return application aliases in an unmodifiable collection
 	 */
 	public List<String> getAliases();
@@ -330,7 +330,7 @@ public interface IApplication extends IOpenShiftResource {
 
 	/**
 	 * Remove application alias
-	 * 
+	 *
 	 * @throws OpenShiftException
 	 */
 	public void removeAlias(String alias) throws OpenShiftException;
@@ -339,7 +339,7 @@ public interface IApplication extends IOpenShiftResource {
 	 * Refresh the application but reloading its content from OpenShift. At the
 	 * same time, this operation automatically set the embedded cartridges back
 	 * to an 'unloaded' state.
-	 * 
+	 *
 	 * @throws OpenShiftException
 	 */
 	public void refresh() throws OpenShiftException;
@@ -349,25 +349,27 @@ public interface IApplication extends IOpenShiftResource {
 	 * OpenShift to perform some operations. This SSH session must be
 	 * initialized out of the library, since the user's SSH settings may depend
 	 * on the runtime environment (Eclipse, etc.).
-	 * 
-	 * @param session
-	 *            the SSH session
+	 *
+	 * @param session the SSH session
+	 *
+	 * @deprecated use {@link IApplicationSSHSession#setSSHSession(com.jcraft.jsch.Session)}
 	 */
 	public void setSSHSession(Session session);
 
 	/**
 	 * Returns the SSH session that this application uses to connect to
 	 * OpenShift.
-	 * 
+	 *
 	 * @return the SSH session that this application uses to connect to
 	 *         OpenShift.
+	 * @deprecated use {@link com.openshift.client.IApplicationSSHSession}
 	 */
 	public Session getSSHSession();
 
 	/**
 	 * Returns true if the application was already provided with an SSH session,
 	 * and this session is still valid (connected).
-	 * 
+	 *
 	 * @return true if the application was already provided with an SSH session,
 	 *         and this session is still valid (connected).
 	 */
@@ -375,55 +377,66 @@ public interface IApplication extends IOpenShiftResource {
 
 	/**
 	 * Returns true if the port-forwarding has been started, false otherwise.
-	 * 
+	 *
 	 * @return true if the port-forwarding has been started, false otherwise.
 	 * @throws OpenShiftSSHOperationException
+	 *
+	 * @deprecated use {@link IApplicationSSHSession#isPortFowardingStarted()}
 	 */
 	public boolean isPortFowardingStarted() throws OpenShiftSSHOperationException;
 
 	/**
 	 * Returns the list of forwardable ports on OpenShift for this application.
-	 * 
+	 *
 	 * @return the list of forwardable ports on OpenShift for this application.
 	 * @throws OpenShiftSSHOperationException
+	 * @deprecated use {@link IApplicationSSHSession#getForwardablePorts()}
 	 */
 	public List<IApplicationPortForwarding> getForwardablePorts() throws OpenShiftSSHOperationException;
 
 	/**
 	 * @ * Starts the port-forwarding for all ports.
-	 * 
+	 *
 	 * @return the list of forwardable ports on OpenShift for this application.
 	 * @throws JSchException
+	 *
+	 * @deprecated use {@link IApplicationSSHSession#startPortForwarding()}
 	 */
 	public List<IApplicationPortForwarding> startPortForwarding() throws OpenShiftSSHOperationException;
 
 	/**
 	 * Stop the port-forwarding for all ports.
-	 * 
+	 *
 	 * @return the list of forwardable ports on OpenShift for this application.
 	 * @throws OpenShiftSSHOperationException
+	 *
+	 * @deprecated use {@link IApplicationSSHSession#stopPortForwarding()}
 	 */
 	public List<IApplicationPortForwarding> stopPortForwarding() throws OpenShiftSSHOperationException;
 
 	/**
 	 * Refreshes the list of port-forwarding. Started ones are kept as-is.
-	 * 
+	 *
 	 * @return the list of forwardable ports on OpenShift for this application.
 	 * @throws OpenShiftSSHOperationException
+	 *
+	 * @deprecated use {@link IApplicationSSHSession#refreshForwardablePorts()}
 	 */
 	public List<IApplicationPortForwarding> refreshForwardablePorts() throws OpenShiftSSHOperationException;
 
 	/**
 	 * Retrieves the list of environment properties.
-	 * 
+	 *
 	 * @return the list of environment properties.
 	 * @throws OpenShiftSSHOperationException
+	 *
+	 * @deprecated use {@link IApplicationSSHSession#getEnvironmentProperties()}
 	 */
 	public List<String> getEnvironmentProperties() throws OpenShiftSSHOperationException;
 
 	/**
 	 * Retrieves the map of environment variables
-	 * 
+	 *
 	 * @return the Map<String,IEnvironmentVariable> of environment variables
 	 * @throws OpenShiftSSHOperationException
 	 */
@@ -431,7 +444,7 @@ public interface IApplication extends IOpenShiftResource {
 
 	/**
 	 * Checks if the environment variable is present in the application.
-	 * 
+	 *
 	 * @param name  Name of the environment variable
 	 * @return <code>true</code> if the current instance has IEnvironmentVariables to return <br>
 	 *         <code>false</code> if the current instance has no IEnvironmentVariables to return
@@ -441,7 +454,7 @@ public interface IApplication extends IOpenShiftResource {
 
 	/**
 	 * Adds an environment variable to this application. 
-	 * 
+	 *
 	 * @param name  key associated with the variable to add
 	 * @param value value of the new variable
 	 * @throws OpenShiftSSHOperationException - if the variable already exists
@@ -460,7 +473,7 @@ public interface IApplication extends IOpenShiftResource {
 
 	/**
 	 * Adds a map of environment variables to the application
-	 * 
+	 *
 	 * @param environmentVariables Map<String,String> of environment variables
 	 * @throws OpenShiftSSHOperationException
 	 */
@@ -469,7 +482,7 @@ public interface IApplication extends IOpenShiftResource {
 
 	/**
 	 * Return the environment variable for the specified name
-	 * 
+	 *
 	 * @param name key to be used to locate the environment variable
 	 * @return IEnvironmentVariable associated with the provided key
 	 * @throws OpenShiftSSHOperationException - thrown if the key does not exist
@@ -487,28 +500,28 @@ public interface IApplication extends IOpenShiftResource {
 
 	/**
 	 * Removes the environment variables with the given name from this application.
-	 * 
+	 *
 	 * @param name key associated with the IEnvironmentVariable to be removed
-	 * @return 
+	 * @return
 	 * @throws OpenShiftException - thrown if there is no IEnvironmentVariable associated with the explicit parameter.
 	 */
 	public void removeEnvironmentVariable(String name) throws OpenShiftException;
-	
+
 	/**
-     * Removes the environment variables with the given name from this application.
-     * 
-     * @param environmentVariable IEnvironmentVariable instance which should be removed
-     * @return 
-     * @throws OpenShiftException - thrown if there is no instance  of IEnvironmentVariable available to be removed
-     */
+	 * Removes the environment variables with the given name from this application.
+	 *
+	 * @param environmentVariable IEnvironmentVariable instance which should be removed
+	 * @return
+	 * @throws OpenShiftException - thrown if there is no instance  of IEnvironmentVariable available to be removed
+	 */
 	public void removeEnvironmentVariable(IEnvironmentVariable environmentVariable);
 
 	/**
 	 * Used to determine if environment variables exist and are available to be retrieved 
-	 * 
+	 *
 	 * @return Returns <code>true</code> if this application can list its environment variables. <br>
 	 *         Returns <code>false</code> if it cannot. Internally this translates to the presence of the link to list environment variables.
-	 * 
+	 *
 	 * @see #getEnvironmentVariablesMap()
 	 * @see #getEnvironmentVariable(String)
 	 * @see ApplicationResource#LINK_LIST_ENVIRONMENT_VARIABLES
@@ -517,10 +530,10 @@ public interface IApplication extends IOpenShiftResource {
 
 	/**
 	 * Used to determine if the current instance is able to update environment variables.
-	 * 
+	 *
 	 * @return Returns <code>true</code> if this application can augment its environment variables.<br>
-     *         Returns <code>false</code> if it cannot. <br>
-	 * 
+	 *         Returns <code>false</code> if it cannot. <br>
+	 *
 	 * @see #addEnvironmentVariable(String, String)
 	 * @see #addEnvironmentVariables(Map)
 	 * @see ApplicationResource#LINK_SET_UNSET_ENVIRONMENT_VARIABLES

--- a/src/main/java/com/openshift/client/IApplicationSSHSession.java
+++ b/src/main/java/com/openshift/client/IApplicationSSHSession.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.client;
+
+import com.jcraft.jsch.Session;
+
+import java.util.List;
+
+/**
+ * @author André Dietisheim
+ * @author Syed Iqbal
+ * @author Martes G Wigglesworth
+ * @author Corey Daley
+ */
+public interface IApplicationSSHSession {
+
+	/**
+	 * Refreshes the list of port-forwarding. Started ones are kept as-is.
+	 *
+	 * @return the list of forwardable ports on OpenShift for this application.
+	 * @throws OpenShiftSSHOperationException
+	 */
+	public List<IApplicationPortForwarding> refreshForwardablePorts() throws OpenShiftSSHOperationException;
+
+	/**
+	 * Returns true if the SSH session provided to the application
+	 * is still valid (connected).
+	 *
+	 * @return true if the SSH session provided to the application
+	 *         is still valid (connected).
+	 */
+	public boolean isSSHSessionConnected();
+
+	/**
+	 * Returns the list of forwardable ports on OpenShift for this application.
+	 *
+	 * @return the list of forwardable ports on OpenShift for this application.
+	 * @throws OpenShiftSSHOperationException
+	 */
+	public List<IApplicationPortForwarding> getForwardablePorts() throws OpenShiftSSHOperationException;
+
+	/**
+	 * Stop the port-forwarding for all ports.
+	 *
+	 * @return the list of forwardable ports on OpenShift for this application.
+	 * @throws OpenShiftSSHOperationException
+	 */
+	public List<IApplicationPortForwarding> stopPortForwarding() throws OpenShiftSSHOperationException;
+
+	/**
+	 * @ * Starts the port-forwarding for all ports.
+	 *
+	 * @return the list of forwardable ports on OpenShift for this application.
+	 * @throws com.jcraft.jsch.JSchException
+	 */
+	public List<IApplicationPortForwarding> startPortForwarding() throws OpenShiftSSHOperationException;
+
+	/**
+	 * Sets the SSH session that this application will use to connect to
+	 * OpenShift to perform some operations. This SSH session must be
+	 * initialized out of the library, since the user's SSH settings may depend
+	 * on the runtime environment (Eclipse, etc.).
+	 *
+	 * @param session
+	 *            the SSH session
+	 */
+	public void setSSHSession(Session session);
+
+	/**
+	 * Retrieves the list of environment properties.
+	 *
+	 * @return the list of environment properties.
+	 * @throws OpenShiftSSHOperationException
+	 */
+	public List<String> getEnvironmentProperties() throws OpenShiftSSHOperationException;
+
+	/**
+	 * Returns true if the port-forwarding has been started, false otherwise.
+	 *
+	 * @return true if the port-forwarding has been started, false otherwise.
+	 * @throws OpenShiftSSHOperationException
+	 */
+	public boolean isPortFowardingStarted() throws OpenShiftSSHOperationException;
+
+
+}

--- a/src/main/java/com/openshift/internal/client/ApplicationResource.java
+++ b/src/main/java/com/openshift/internal/client/ApplicationResource.java
@@ -4,7 +4,7 @@
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
  * and is available at http://www.eclipse.org/legal/epl-v10.html 
- * 
+ *
  * Contributors: 
  * Red Hat, Inc. - initial API and implementation 
  ******************************************************************************/
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 
+import com.openshift.client.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,17 +38,6 @@ import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
-import com.openshift.client.ApplicationScale;
-import com.openshift.client.IApplication;
-import com.openshift.client.IApplicationPortForwarding;
-import com.openshift.client.IDomain;
-import com.openshift.client.IEnvironmentVariable;
-import com.openshift.client.IGearGroup;
-import com.openshift.client.IGearProfile;
-import com.openshift.client.IOpenShiftConnection;
-import com.openshift.client.Messages;
-import com.openshift.client.OpenShiftException;
-import com.openshift.client.OpenShiftSSHOperationException;
 import com.openshift.client.cartridge.ICartridge;
 import com.openshift.client.cartridge.IEmbeddableCartridge;
 import com.openshift.client.cartridge.IEmbeddedCartridge;
@@ -69,7 +59,7 @@ import com.openshift.internal.client.utils.StringUtils;
 /**
  * The ApplicationResource object is an implementation of com.openshift.client.IApplication, and provides 
  * a runtime model for the real application that resides on the OpenShift platform being accessed.
- * 
+ *
  * @author André Dietisheim
  * @author Syed Iqbal
  * @author Martes G Wigglesworth
@@ -78,7 +68,7 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 
 	private static final long APPLICATION_WAIT_RETRY_DELAY = 2 * 1024;
 	private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationResource.class);
-	
+
 	private static final String LINK_DELETE_APPLICATION = "DELETE";
 	private static final String LINK_START_APPLICATION = "START";
 	private static final String LINK_STOP_APPLICATION = "STOP";
@@ -91,10 +81,10 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 	private static final String LINK_ADD_CARTRIDGE = "ADD_CARTRIDGE";
 	private static final String LINK_LIST_CARTRIDGES = "LIST_CARTRIDGES";
 	private static final String LINK_GET_GEAR_GROUPS = "GET_GEAR_GROUPS";
-    private static final String LINK_LIST_ENVIRONMENT_VARIABLES = "LIST_ENVIRONMENT_VARIABLES";
-    private static final String LINK_SET_UNSET_ENVIRONMENT_VARIABLES = "SET_UNSET_ENVIRONMENT_VARIABLES";
-    private static final Pattern REGEX_FORWARDED_PORT = Pattern.compile("([^ ]+) -> ([^:]+):(\\d+)");
-	
+	private static final String LINK_LIST_ENVIRONMENT_VARIABLES = "LIST_ENVIRONMENT_VARIABLES";
+	private static final String LINK_SET_UNSET_ENVIRONMENT_VARIABLES = "SET_UNSET_ENVIRONMENT_VARIABLES";
+	private static final Pattern REGEX_FORWARDED_PORT = Pattern.compile("([^ ]+) -> ([^:]+):(\\d+)");
+
 	/** The (unique) uuid of this application. */
 	private String uuid;
 
@@ -121,13 +111,13 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 
 	/** The url to use to connect with ssh.*/
 	private String sshUrl;
-	
+
 	/** The url at which the git repo of this application may be reached. */
 	private String gitUrl;
 
 	/** the git url for the initial code and configuration for the application */
 	private String initialGitUrl;
-	
+
 	/** The aliases of this application. */
 	private List<String> aliases;
 
@@ -146,7 +136,7 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 	 * operations.
 	 */
 	private Session session;
-	
+
 	private Collection<IGearGroup> gearGroups;
 	/**
 	 * The environment variables for this application
@@ -156,13 +146,13 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 
 	protected ApplicationResource(ApplicationResourceDTO dto, DomainResource domain) {
 		this(dto.getName(), dto.getUuid(), dto.getCreationTime(), dto.getMessages(), dto.getApplicationUrl(),
-				dto.getSshUrl(), dto.getGitUrl(), dto.getInitialGitUrl(), dto.getGearProfile(), dto.getApplicationScale(), 
-				dto.getAliases(), dto.getCartridges(), dto.getLinks(), domain);
+			dto.getSshUrl(), dto.getGitUrl(), dto.getInitialGitUrl(), dto.getGearProfile(), dto.getApplicationScale(),
+			dto.getAliases(), dto.getCartridges(), dto.getLinks(), domain);
 	}
 
 	/**
 	 * Instantiates a new application.
-	 * 
+	 *
 	 * @param name
 	 *            the name
 	 * @param uuid
@@ -188,10 +178,10 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 	 * @throws DatatypeConfigurationException
 	 */
 	protected ApplicationResource(final String name, final String uuid, final String creationTime,
-			final Messages messages, final String applicationUrl, final String sshUrl, final String gitUrl, 
-			final String initialGitUrl, final IGearProfile gearProfile, final ApplicationScale scale, final List<String> aliases,
-			final Map<String, CartridgeResourceDTO> cartridgesByName, final Map<String, Link> links,
-			final DomainResource domain) {
+								final Messages messages, final String applicationUrl, final String sshUrl, final String gitUrl,
+								final String initialGitUrl, final IGearProfile gearProfile, final ApplicationScale scale, final List<String> aliases,
+								final Map<String, CartridgeResourceDTO> cartridgesByName, final Map<String, Link> links,
+								final DomainResource domain) {
 		super(domain.getService(), links, messages);
 		this.name = name;
 		this.uuid = uuid;
@@ -345,7 +335,7 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 
 	/**
 	 * Adds the given embedded cartridge to this application.
-	 * 
+	 *
 	 * @param cartridge
 	 *            the embeddable cartridge that shall be added to this
 	 *            application
@@ -375,7 +365,7 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 
 	/**
 	 * "callback" from the embeddedCartridge once it has been destroyed.
-	 * 
+	 *
 	 * @param embeddedCartridge
 	 * @throws OpenShiftException
 	 */
@@ -388,7 +378,7 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 	/**
 	 * Queries the backend to list the embedded cartridges and adds the new ones
 	 * & update the ones that are already present
-	 * 
+	 *
 	 * @throws OpenShiftException
 	 */
 	protected void refreshEmbeddedCartridges() throws OpenShiftException {
@@ -401,19 +391,19 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 	private void updateCartridges(Map<String, CartridgeResourceDTO> cartridgeDTOByName) {
 		for (CartridgeResourceDTO cartridgeDTO : cartridgeDTOByName.values()) {
 			switch(cartridgeDTO.getType()) {
-			case STANDALONE:
-				createStandaloneCartrdige(cartridgeDTO);
-				break;
-			case EMBEDDED:
-				addOrUpdateEmbeddedCartridge(cartridgeDTO.getName(), cartridgeDTO);
+				case STANDALONE:
+					createStandaloneCartrdige(cartridgeDTO);
+					break;
+				case EMBEDDED:
+					addOrUpdateEmbeddedCartridge(cartridgeDTO.getName(), cartridgeDTO);
 			}
 		}
 	}
 
 	private void createStandaloneCartrdige(CartridgeResourceDTO cartridgeDTO) {
 		this.cartridge = new StandaloneCartridge(
-				cartridgeDTO.getName(), 
-				cartridgeDTO.getUrl(), 
+				cartridgeDTO.getName(),
+				cartridgeDTO.getUrl(),
 				cartridgeDTO.getDisplayName(),
 				cartridgeDTO.getDescription());
 	}
@@ -437,7 +427,7 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 			}
 		}
 	}
-	
+
 	public List<IEmbeddedCartridge> getEmbeddedCartridges() throws OpenShiftException {
 		return Collections.unmodifiableList(new ArrayList<IEmbeddedCartridge>(this.embeddedCartridgesByName.values()));
 	}
@@ -473,7 +463,7 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 		}
 		return null;
 	}
-		
+
 	public void removeEmbeddedCartridge(IEmbeddableCartridge cartridge) throws OpenShiftException {
 		Assert.notNull(cartridge);
 
@@ -502,14 +492,14 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 
 	private Collection<IGearGroup> loadGearGroups() throws OpenShiftException {
 		List<IGearGroup> gearGroups = new ArrayList<IGearGroup>();
-		Collection<GearGroupResourceDTO> dtos = new GetGearGroupsRequest().execute(); 
+		Collection<GearGroupResourceDTO> dtos = new GetGearGroupsRequest().execute();
 		for(GearGroupResourceDTO dto : dtos) {
 			gearGroups.add(new GearGroupResource(dto, this, getService()));
 		}
-		
+
 		return this.gearGroups = gearGroups;
 	}
-	
+
 	public boolean waitForAccessible(long timeout) throws OpenShiftException {
 		try {
 			return waitForResolved(timeout, System.currentTimeMillis());
@@ -527,7 +517,7 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 			}
 		});
 	}
-	
+
 	protected IOpenShiftConnection getConnection() {
 		return getDomain().getUser().getConnection();
 	}
@@ -549,7 +539,7 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 	protected boolean canResolv(String url) throws MalformedURLException {
 		return HostUtils.canResolv(url);
 	}
-	
+
 	private boolean isTimeouted(long timeout, long startTime) {
 		return !(System.currentTimeMillis() < (startTime + timeout));
 	}
@@ -608,19 +598,19 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 		}
 		return openshiftProps;
 	}
-	
+
 	@Override
 	public Map<String, IEnvironmentVariable> getEnvironmentVariables() throws OpenShiftException {
 		return Collections.unmodifiableMap(new LinkedHashMap<String, IEnvironmentVariable>(getOrLoadEnvironmentVariables()));
 	}
 
-	
-  protected Map<String, IEnvironmentVariable> getOrLoadEnvironmentVariables() throws OpenShiftException {
-	if(environmentVariablesMap.isEmpty())
-	   environmentVariablesMap = loadEnvironmentVariables();		
-	return environmentVariablesMap;
+
+	protected Map<String, IEnvironmentVariable> getOrLoadEnvironmentVariables() throws OpenShiftException {
+		if(environmentVariablesMap.isEmpty())
+			environmentVariablesMap = loadEnvironmentVariables();
+		return environmentVariablesMap;
 	}
-	
+
 	private Map<String, IEnvironmentVariable> loadEnvironmentVariables() throws OpenShiftException {
 		List<EnvironmentVariableResourceDTO> environmentVariableDTOs = new ListEnvironmentVariablesRequest().execute();
 		if (environmentVariableDTOs == null) {
@@ -628,11 +618,11 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 		}
 
 		for (EnvironmentVariableResourceDTO environmentVariableResourceDTO : environmentVariableDTOs) {
-			final IEnvironmentVariable environmentVariable = 
+			final IEnvironmentVariable environmentVariable =
 					new EnvironmentVariableResource(environmentVariableResourceDTO, this);
-			
+
 			environmentVariablesMap.put(environmentVariable.getName(),environmentVariable);
-			
+
 		}
 		return environmentVariablesMap;
 	}
@@ -647,14 +637,14 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 		}
 		if (hasEnvironmentVariable(name)) {
 			throw new OpenShiftException("Environment variable with name \"{0}\" already exists.", name);
-		}		
-		
+		}
+
 		EnvironmentVariableResourceDTO environmentVariableResourceDTO =
-				new AddEnvironmentVariableRequest().execute(name, value);		
+				new AddEnvironmentVariableRequest().execute(name, value);
 		IEnvironmentVariable environmentVariable = new EnvironmentVariableResource(environmentVariableResourceDTO, this);
-		
+
 		environmentVariablesMap.put(environmentVariable.getName(), environmentVariable);
-		
+
 		return environmentVariable;
 	}
 
@@ -681,54 +671,54 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 	@Override
 	public Map<String, IEnvironmentVariable> addEnvironmentVariables(Map<String, String> environmentVariables)
 			throws OpenShiftException {
-	  
-	  Map<String,String>variablesCandidateMap = new HashMap<String,String>();
-	  for(String varCandidateName:environmentVariables.keySet()){
-	    IEnvironmentVariable tempVar = environmentVariablesMap.get(varCandidateName);
-	    if(tempVar != null)
-	    {  if(tempVar.getValue() == environmentVariables.get(varCandidateName))
-	        variablesCandidateMap.put(varCandidateName,environmentVariables.get(varCandidateName));
-	    }
-	    else
-	        variablesCandidateMap.put(varCandidateName, environmentVariables.get(varCandidateName));
-	  }
-	  List<EnvironmentVariableResourceDTO> environmentVariableResourceDTOs = new AddEnvironmentVariablesRequest()
+
+		Map<String,String>variablesCandidateMap = new HashMap<String,String>();
+		for(String varCandidateName:environmentVariables.keySet()){
+			IEnvironmentVariable tempVar = environmentVariablesMap.get(varCandidateName);
+			if(tempVar != null)
+			{  if(tempVar.getValue() == environmentVariables.get(varCandidateName))
+				variablesCandidateMap.put(varCandidateName,environmentVariables.get(varCandidateName));
+			}
+			else
+				variablesCandidateMap.put(varCandidateName, environmentVariables.get(varCandidateName));
+		}
+		List<EnvironmentVariableResourceDTO> environmentVariableResourceDTOs = new AddEnvironmentVariablesRequest()
 				.execute(variablesCandidateMap);
-		
+
 		for (EnvironmentVariableResourceDTO dto : environmentVariableResourceDTOs) {
 			IEnvironmentVariable environmentVariable = new EnvironmentVariableResource(dto, this);
 			environmentVariablesMap.put(environmentVariable.getName(), environmentVariable);
 		}
-		
+
 		return environmentVariablesMap;
 	}
-    /*
-     * (non-Javadoc)
-     * @see com.openshift.client.IApplication#removeEnvironmentVariable(java.lang.String)
-     */
+	/*
+	 * (non-Javadoc)
+	 * @see com.openshift.client.IApplication#removeEnvironmentVariable(java.lang.String)
+	 */
 	@Override
 	public void removeEnvironmentVariable(String targetName) {
-		removeEnvironmentVariable(getEnvironmentVariable(targetName));		
+		removeEnvironmentVariable(getEnvironmentVariable(targetName));
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see com.openshift.client.IApplication#removeEnvironmentVariable(com.openshift.client.IEnvironmentVariable)
 	 */
 	@Override
-	public void removeEnvironmentVariable(IEnvironmentVariable environmentVariable){      
-      if(getEnvironmentVariable(environmentVariable.getName()) == null)
-        throw new OpenShiftException("IEnvironmentVariable with supplied name does not exist.");
-      environmentVariable.destroy();
-      environmentVariablesMap.remove(environmentVariable.getName());
-     
-    }
-	
-	
+	public void removeEnvironmentVariable(IEnvironmentVariable environmentVariable){
+		if(getEnvironmentVariable(environmentVariable.getName()) == null)
+			throw new OpenShiftException("IEnvironmentVariable with supplied name does not exist.");
+		environmentVariable.destroy();
+		environmentVariablesMap.remove(environmentVariable.getName());
+
+	}
+
+
 	/*
 	 * (non-Javadoc)
 	 * @see com.openshift.client.IApplication#hasEnvironmentVariable(java.lang.String)
 	 */
-    @Override
+	@Override
 	public boolean hasEnvironmentVariable(String name) throws OpenShiftException {
 		if (StringUtils.isEmpty(name)) {
 			throw new OpenShiftException("Environment variable name is mandatory but none was given.");
@@ -736,18 +726,18 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 		return getEnvironmentVariable(name) != null;
 
 	}
-    
+
 	protected void updateEnvironmentVariables() throws OpenShiftException {
-		if (!canGetEnvironmentVariables()) 
+		if (!canGetEnvironmentVariables())
 			return;
 		else
 		{
-		  environmentVariablesMap.clear();
-		  environmentVariablesMap = loadEnvironmentVariables();
+			environmentVariablesMap.clear();
+			environmentVariablesMap = loadEnvironmentVariables();
 		}
 
 	}
-    
+
 	/*
 	 * (non-Javadoc)
 	 * @see com.openshift.client.IApplication#getEnvironmentVariable(java.lang.String)
@@ -786,11 +776,11 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 		} catch (OpenShiftException e) {
 			return false;
 		}
-	}    
-  
+	}
+
 	/**
 	 * List all forwardable ports for a given application.
-	 * 
+	 *
 	 * @param application
 	 * @return the forwardable ports in an unmodifiable collection
 	 * @throws JSchException
@@ -809,7 +799,7 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 	}
 
 	/**
-	 * 
+	 *
 	 * @param command
 	 * @return
 	 * @throws OpenShiftSSHOperationException
@@ -854,7 +844,7 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 	 * Extract the named forwardable port from the 'rhc-list-ports' command
 	 * result line, with the following format:
 	 * <code>java -> 127.10.187.1:4447</code>.
-	 * 
+	 *
 	 * @param portValue
 	 * @return the forwardable port.
 	 */
@@ -924,7 +914,7 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 		this.aliases = dto.getAliases();
 		updateCartridges(dto.getCartridges());
 	}
-	
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
@@ -972,15 +962,15 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 	protected enum SshStreams {
 		EXT_INPUT {
 			protected InputStream getInputStream(Channel channel) throws IOException {
-				return channel.getExtInputStream(); 
+				return channel.getExtInputStream();
 			}
 
 		}, INPUT {
 			protected InputStream getInputStream(Channel channel) throws IOException {
-				return channel.getInputStream(); 
+				return channel.getInputStream();
 			}
 		};
-		
+
 		public List<String> getLines(Channel channel) throws IOException {
 			BufferedReader reader = new BufferedReader(new InputStreamReader(getInputStream(channel)));
 			List<String> lines = new ArrayList<String>();
@@ -991,11 +981,11 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 			}
 			return lines;
 		}
-		
+
 		protected abstract InputStream getInputStream(Channel channel) throws IOException;
 
 	}
-	
+
 	private class DeleteApplicationRequest extends ServiceRequest {
 
 		private DeleteApplicationRequest() {
@@ -1083,7 +1073,7 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 
 		protected <DTO> DTO execute(String alias) throws OpenShiftException {
 			return super.execute(
-					new StringParameter(IOpenShiftJsonConstants.PROPERTY_EVENT, IOpenShiftJsonConstants.VALUE_ADD_ALIAS), 
+					new StringParameter(IOpenShiftJsonConstants.PROPERTY_EVENT, IOpenShiftJsonConstants.VALUE_ADD_ALIAS),
 					new StringParameter(IOpenShiftJsonConstants.PROPERTY_ALIAS, alias));
 		}
 	}
@@ -1096,7 +1086,7 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 
 		protected <DTO> DTO execute(String alias) throws OpenShiftException {
 			return super.execute(
-					new StringParameter(IOpenShiftJsonConstants.PROPERTY_EVENT, IOpenShiftJsonConstants.VALUE_REMOVE_ALIAS), 
+					new StringParameter(IOpenShiftJsonConstants.PROPERTY_EVENT, IOpenShiftJsonConstants.VALUE_REMOVE_ALIAS),
 					new StringParameter(IOpenShiftJsonConstants.PROPERTY_ALIAS, alias));
 		}
 	}
@@ -1122,14 +1112,14 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 			return super.execute();
 		}
 	}
-	
+
 	private class GetGearGroupsRequest extends ServiceRequest {
 
 		private GetGearGroupsRequest() {
 			super(LINK_GET_GEAR_GROUPS);
 		}
 	}
-	
+
 	private class ListEnvironmentVariablesRequest extends ServiceRequest {
 		protected ListEnvironmentVariablesRequest() {
 			super(LINK_LIST_ENVIRONMENT_VARIABLES);
@@ -1148,7 +1138,7 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 			return super.execute(parameters.toArray());
 		}
 	}
-	
+
 	private class AddEnvironmentVariablesRequest extends ServiceRequest {
 		protected AddEnvironmentVariablesRequest() {
 			super(LINK_SET_UNSET_ENVIRONMENT_VARIABLES);
@@ -1162,4 +1152,4 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 		}
 	}
 
- }
+}

--- a/src/main/java/com/openshift/internal/client/ApplicationSSHSession.java
+++ b/src/main/java/com/openshift/internal/client/ApplicationSSHSession.java
@@ -1,0 +1,347 @@
+/*******************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.internal.client;
+
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.ChannelExec;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import com.openshift.client.*;
+import com.openshift.internal.client.ssh.ApplicationPortForwarding;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author André Dietisheim
+ * @author Syed Iqbal
+ * @author Martes G Wigglesworth
+ * @author Corey Daley
+ */
+public class ApplicationSSHSession implements IApplicationSSHSession {
+
+	/** SSH Session to use for all methods */
+	private Session session;
+
+	/** Application that is associated with this SSH Session */
+	private IApplication application;
+
+	/** List of ports available for port forwarding */
+	private List<IApplicationPortForwarding> ports = null;
+
+	/** Regex for port forwarding */
+	private static final Pattern REGEX_FORWARDED_PORT = Pattern.compile("([^ ]+) -> ([^:]+):(\\d+)");
+
+	/** Logger */
+	private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationSSHSession.class);
+
+	/**
+	 * Sets the SSH session that this application will use to connect to
+	 * OpenShift to perform some operations. This SSH session must be
+	 * initialized out of the library, since the user's SSH settings may depend
+	 * on the runtime environment (Eclipse, etc.).
+	 *
+	 * @param application
+	 * @param session
+	 * @return An instance of ApplicationSSHSession used for running all methods that require an SSH session
+	 */
+	ApplicationSSHSession(IApplication application, Session session) {
+		this.application = application;
+		this.session = session;
+	}
+
+	/**
+	 * Set the current SSH session
+	 * @param session
+	 */
+	public void setSSHSession(final Session session) {this.session = session;}
+
+	/**
+	 * Get the application associated with this ApplicationSSHSession
+	 * @return The application associated with this ssh session
+	 */
+	public IApplication getApplication() {return this.application;}
+
+	/**
+	 * Check if the current SSH session is connected
+	 * @return True if the SSH session is connected
+	 */
+	public boolean isSSHSessionConnected() {
+		return this.session.isConnected();
+	}
+
+	/**
+	 * Check if port forwarding has been started
+	 * @return true if port forwarding is started, false otherwise
+	 * @throws OpenShiftSSHOperationException
+	 */
+	public boolean isPortFowardingStarted() throws OpenShiftSSHOperationException {
+		try {
+			return isSSHSessionConnected() && this.session.getPortForwardingL().length > 0;
+		} catch (JSchException e) {
+			throw new OpenShiftSSHOperationException(e,
+					"Unable to verify if port-forwarding has been started for application \"{0}\"", application.getName());
+		}
+	}
+
+	/**
+	 * Start forwarding available ports to this application
+	 * @return Current list of ports
+	 * @throws OpenShiftSSHOperationException
+	 */
+	public List<IApplicationPortForwarding> startPortForwarding() throws OpenShiftSSHOperationException {
+		if (!isSSHSessionConnected()) {
+			throw new OpenShiftSSHOperationException(
+					"SSH session for application ''{0}'' is closed. Cannot start port forwarding",
+					application.getName());
+		}
+		for (IApplicationPortForwarding port : ports) {
+			try {
+				port.start(session);
+			} catch (OpenShiftSSHOperationException oss) {
+				/*
+				 * ignore for now
+				 * FIXME: should store this error on the forward to let user
+				 * know why it could not start/stop
+				 */
+			}
+		}
+		return ports;
+	}
+
+	/**
+	 * Stop forwarding of all ports to this application
+	 * @return The current list of ports
+	 * @throws OpenShiftSSHOperationException
+	 */
+	public List<IApplicationPortForwarding> stopPortForwarding() throws OpenShiftSSHOperationException {
+		for (IApplicationPortForwarding port : ports) {
+			try {
+				port.stop(session);
+			} catch (OpenShiftSSHOperationException oss) {
+				/* ignore for now
+				 *  should store this error on the forward to let user know why
+				 *  it could not start/stop
+				 */
+			}
+		}
+		// make sure port forwarding is stopped by closing session...
+		session.disconnect();
+		return ports;
+	}
+
+	/**
+	 * Refresh the list of forwardable ports for an application
+	 * @return List of forwardable ports for your application
+	 * @throws OpenShiftSSHOperationException
+	 */
+	public List<IApplicationPortForwarding> refreshForwardablePorts() throws OpenShiftSSHOperationException {
+		this.ports = loadPorts();
+		return getForwardablePorts();
+	}
+
+	/**
+	 * Gets a list of forwardable ports for your application
+	 * @return List of forwardable ports for your application
+	 * @throws OpenShiftSSHOperationException
+	 */
+	public List<IApplicationPortForwarding> getForwardablePorts() throws OpenShiftSSHOperationException {
+		if (ports == null) {
+			this.ports = loadPorts();
+		}
+		return ports;
+	}
+
+	/**
+	 * Extract the named forwardable port from the 'rhc-list-ports' command
+	 * result line, with the following format:
+	 * <code>java -> 127.10.187.1:4447</code>.
+	 *
+	 * @param portValue
+	 * @return the forwardable port.
+	 */
+	private ApplicationPortForwarding extractForwardablePortFrom(final String portValue) {
+		Matcher matcher = REGEX_FORWARDED_PORT.matcher(portValue);
+		if (!matcher.find()
+				|| matcher.groupCount() != 3) {
+			return null;
+		}
+		try {
+			final String name = matcher.group(1);
+			final String host = matcher.group(2);
+			final int remotePort = Integer.parseInt(matcher.group(3));
+			return new ApplicationPortForwarding(application, name, host, remotePort);
+		} catch(NumberFormatException e) {
+			throw new OpenShiftSSHOperationException(e,
+					"Couild not determine forwarded port in application {0}", application.getName());
+		}
+	}
+
+	/**
+	 * Get a list of properties from your OpenShift Application
+	 * @return List of properties from your OpenShift application
+	 * @throws OpenShiftSSHOperationException
+	 */
+	@Override
+	public List<String> getEnvironmentProperties() throws OpenShiftSSHOperationException {
+		List<String> openshiftProps = new ArrayList<String>();
+		List<String> allEnvProps = sshExecCmd("set", SshStreams.INPUT);
+		for (String line : allEnvProps) {
+			openshiftProps.add(line);
+		}
+		return openshiftProps;
+	}
+
+	/**
+	 * List all forwardable ports for a given application.
+	 *
+	 * @return the forwardable ports in an unmodifiable collection
+	 * @throws JSchException
+	 * @throws OpenShiftSSHOperationException
+	 */
+	private List<IApplicationPortForwarding> loadPorts() throws OpenShiftSSHOperationException {
+		this.ports = new ArrayList<IApplicationPortForwarding>();
+		List<String> lines = sshExecCmd("rhc-list-ports", SshStreams.EXT_INPUT);
+		for (String line : lines) {
+			ApplicationPortForwarding port = extractForwardablePortFrom(line);
+			if (port != null) {
+				ports.add(port);
+			}
+		}
+		return ports;
+	}
+
+	/**
+	 * Refreshes the list of ports
+	 * @throws OpenShiftException
+	 */
+	public void refresh() throws OpenShiftException {
+		if (this.ports != null) {
+			this.ports = loadPorts();
+		}
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+		if (object == null) {
+			return false;
+		}
+		if (getClass() != object.getClass()) {
+			return false;
+		}
+		ApplicationSSHSession other = (ApplicationSSHSession) object;
+		ApplicationResource otherapp = (ApplicationResource) ((ApplicationSSHSession) object).getApplication();
+		if (application.getUUID() == null) {
+			if (otherapp.getUUID() != null) {
+				return false;
+			}
+		} else if (!application.getUUID().equals(otherapp.getUUID())) {
+			return false;
+		} else if (this.isSSHSessionConnected() != other.isSSHSessionConnected()) {
+			return false;
+		} else if (isPortFowardingStarted() != other.isPortFowardingStarted()) {
+			return false;
+		} else if (this.application != otherapp) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "ApplicationSSHSession ["
+				+ "applicationuuid=" + application.getUUID()
+				+ ", applicationname=" + application.getName()
+				+ ", isconnected=" + isSSHSessionConnected()
+				+ ", isportforwardingstarted=" + isPortFowardingStarted()
+				+ "]";
+	}
+
+	protected enum SshStreams {
+		EXT_INPUT {
+			protected InputStream getInputStream(Channel channel) throws IOException {
+				return channel.getExtInputStream();
+			}
+
+		}, INPUT {
+			protected InputStream getInputStream(Channel channel) throws IOException {
+				return channel.getInputStream();
+			}
+		};
+
+		public List<String> getLines(Channel channel) throws IOException {
+			BufferedReader reader = new BufferedReader(new InputStreamReader(getInputStream(channel)));
+			List<String> lines = new ArrayList<String>();
+			String line = null;
+			// Read File Line By Line
+			while ((line = reader.readLine()) != null) {
+				lines.add(line);
+			}
+			return lines;
+		}
+		protected abstract InputStream getInputStream(Channel channel) throws IOException;
+	}
+
+	/**
+	 *
+	 * @param command
+	 * @return
+	 * @throws OpenShiftSSHOperationException
+	 */
+	protected List<String> sshExecCmd(final String command, final SshStreams sshStream)
+			throws OpenShiftSSHOperationException {
+		final Session session = this.session;
+		if (session == null) {
+			throw new OpenShiftSSHOperationException(
+					"No SSH session available for application ''{0}''.  Please supply an SSH session using ApplicationResource@setSSHSession.",
+					application.getName());
+		}
+		Channel channel = null;
+		BufferedReader reader = null;
+		try {
+			session.openChannel("exec");
+			channel = session.openChannel("exec");
+			((ChannelExec) channel).setCommand(command);
+			channel.connect();
+			return sshStream.getLines(channel);
+		} catch (JSchException e) {
+			throw new OpenShiftSSHOperationException(e, "Failed to execute remote ssh command \"{0}\"",
+					application.getName());
+		} catch (IOException e) {
+			throw new OpenShiftSSHOperationException(e, "Failed to execute remote ssh command \"{0}\"",
+					application.getName());
+		} finally {
+
+			if (reader != null) {
+				try {
+					reader.close();
+				} catch (IOException e) {
+					LOGGER.error("Failed to close SSH error stream reader", e);
+				}
+			}
+
+			if (channel != null && channel.isConnected()) {
+				channel.disconnect();
+			}
+		}
+	}
+}

--- a/src/test/java/com/openshift/internal/client/ApplicationResourceTest.java
+++ b/src/test/java/com/openshift/internal/client/ApplicationResourceTest.java
@@ -25,19 +25,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.jcraft.jsch.JSch;
+import com.openshift.client.*;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.openshift.client.IApplication;
-import com.openshift.client.IApplicationPortForwarding;
-import com.openshift.client.IDomain;
-import com.openshift.client.IEnvironmentVariable;
-import com.openshift.client.IField;
-import com.openshift.client.OpenShiftEndpointException;
-import com.openshift.client.OpenShiftException;
-import com.openshift.client.OpenShiftTimeoutException;
 import com.openshift.client.cartridge.EmbeddableCartridge;
 import com.openshift.client.cartridge.IEmbeddableCartridge;
 import com.openshift.client.cartridge.IEmbeddedCartridge;
@@ -527,11 +521,14 @@ public class ApplicationResourceTest extends TestTimer {
 				" java -> 127.7.233.1:9999",
 				" mysql -> 5190d701500446506a0000e4-foobarz.rhcloud.com:56756" };
 		ApplicationResource spy = Mockito.spy(((ApplicationResource) app));
-		Mockito.doReturn(Arrays.asList(rhcListPortsOutput)).when(spy)
-				.sshExecCmd(Mockito.anyString(), (ApplicationResource.SshStreams) Mockito.any());
+		JSch jsch = new JSch();
+		final IApplicationSSHSession ses = new ApplicationSSHSession(spy, jsch.getSession("mockuser", "mockhost", 22));
+		ApplicationSSHSession spyses = Mockito.spy(((ApplicationSSHSession) ses));
+		Mockito.doReturn(Arrays.asList(rhcListPortsOutput)).when(spyses)
+				.sshExecCmd(Mockito.anyString(), (ApplicationSSHSession.SshStreams) Mockito.any());
 
 		// operation
-		List<IApplicationPortForwarding> forwardablePorts = spy.getForwardablePorts();
+		List<IApplicationPortForwarding> forwardablePorts = spyses.getForwardablePorts();
 
 		// verification
 		assertThat(forwardablePorts).isNotEmpty().hasSize(10);


### PR DESCRIPTION
Adding more detail to the SSH Operation Exceptions to let the user know they need to set an SSH Session using ApplicationResource#setSSHSEssion, also split hasSSHSession into two methods so the exceptions can be more focused and detailed.
