### PR TITLE
[JBIDE-126] Corrected scopes, expires_in_seconds

### DIFF
--- a/src/main/java/com/openshift/client/IAuthorization.java
+++ b/src/main/java/com/openshift/client/IAuthorization.java
@@ -21,7 +21,8 @@ package com.openshift.client;
 public interface IAuthorization extends IOpenShiftResource {
 
 	public static String SCOPE_SESSION = "session";
-	public static String SCOPE_SESSION_READ = "session read";
+	public static String SCOPE_READ = "read";
+	public static String SCOPE_USERINFO = "userinfo";
 	public static int NO_EXPIRES_IN = -1;
 
 	/**

--- a/src/main/java/com/openshift/internal/client/AuthorizationResource.java
+++ b/src/main/java/com/openshift/internal/client/AuthorizationResource.java
@@ -62,7 +62,7 @@ public class AuthorizationResource extends AbstractOpenShiftResource implements 
 				+ "id=" + id + ", "
 				+ "note=" + note + ", "
 				+ "scopes=" + scopes + ", "
-				+ "token=" + token
+				+ "token=" + token + ", "
 				+ "expiresIn=" + expiresIn
 				+ "]";
 	}

--- a/src/main/java/com/openshift/internal/client/response/OpenShiftJsonDTOFactory.java
+++ b/src/main/java/com/openshift/internal/client/response/OpenShiftJsonDTOFactory.java
@@ -20,7 +20,7 @@ import static com.openshift.internal.client.utils.IOpenShiftJsonConstants.PROPER
 import static com.openshift.internal.client.utils.IOpenShiftJsonConstants.PROPERTY_DESCRIPTION;
 import static com.openshift.internal.client.utils.IOpenShiftJsonConstants.PROPERTY_DISPLAY_NAME;
 import static com.openshift.internal.client.utils.IOpenShiftJsonConstants.PROPERTY_DOMAIN_ID;
-import static com.openshift.internal.client.utils.IOpenShiftJsonConstants.PROPERTY_EXPIRES_IN;
+import static com.openshift.internal.client.utils.IOpenShiftJsonConstants.PROPERTY_EXPIRES_IN_SECONDS;
 import static com.openshift.internal.client.utils.IOpenShiftJsonConstants.PROPERTY_FRAMEWORK;
 import static com.openshift.internal.client.utils.IOpenShiftJsonConstants.PROPERTY_GEARS;
 import static com.openshift.internal.client.utils.IOpenShiftJsonConstants.PROPERTY_GEAR_PROFILE;
@@ -161,7 +161,7 @@ public class OpenShiftJsonDTOFactory extends AbstractJsonDTOFactory {
         final String note = getAsString(dataNode, PROPERTY_NOTE);
         final String scopes = getAsString(dataNode, PROPERTY_SCOPES);
         final String token = getAsString(dataNode, PROPERTY_TOKEN);
-        final int expiresIn = getAsInteger(dataNode, PROPERTY_EXPIRES_IN);
+        final int expiresIn = getAsInteger(dataNode, PROPERTY_EXPIRES_IN_SECONDS);
         final Map<String, Link> links = createLinks(dataNode.get(PROPERTY_LINKS));
         return new AuthorizationResourceDTO(id, note, scopes, token, expiresIn, links, messages);
      }

--- a/src/main/java/com/openshift/internal/client/utils/IOpenShiftJsonConstants.java
+++ b/src/main/java/com/openshift/internal/client/utils/IOpenShiftJsonConstants.java
@@ -55,7 +55,8 @@ public class IOpenShiftJsonConstants {
 	public static final String PROPERTY_INFO = "info";
 	public static final String PROPERTY_NOTE= "note";
 	public static final String PROPERTY_SCOPES= "scopes";
-    public static final String PROPERTY_EXPIRES_IN= "expires_in";
+	public static final String PROPERTY_EXPIRES_IN= "expires_in";
+	public static final String PROPERTY_EXPIRES_IN_SECONDS= "expires_in_seconds";
 	public static final String PROPERTY_TOKEN= "token";
 	public static final String PROPERTY_INITIAL_GIT_URL = "initial_git_url";
 	public static final String PROPERTY_INTERNAL_PORT = "internal_port";

--- a/src/test/java/com/openshift/internal/client/AuthorizationTest.java
+++ b/src/test/java/com/openshift/internal/client/AuthorizationTest.java
@@ -66,7 +66,7 @@ public class AuthorizationTest extends TestTimer {
 	@Test
 	public void shouldCreateAuthorization() throws Exception {
 		// pre-conditions
-		IAuthorization authorization = user.createAuthorization("my note", IAuthorization.SCOPE_SESSION_READ);
+		IAuthorization authorization = user.createAuthorization("my note", IAuthorization.SCOPE_SESSION);
 		assertNotNull(authorization.getToken());
 
 		// operations
@@ -75,7 +75,7 @@ public class AuthorizationTest extends TestTimer {
 		authorization = connection.getUser().getAuthorization();
 
 		// verifications
-		assertEquals(authorization.getScopes(), IAuthorization.SCOPE_SESSION_READ);
+		assertEquals(authorization.getScopes(), IAuthorization.SCOPE_SESSION);
 		assertEquals(authorization.getNote(), "my note");
 
 		authorization.destroy();
@@ -84,7 +84,7 @@ public class AuthorizationTest extends TestTimer {
 	@Test
 	public void shouldCreateAuthorizationWithExpiration() throws Exception {
 		// pre-conditions
-		IAuthorization authorization = user.createAuthorization("my note", IAuthorization.SCOPE_SESSION_READ, 600);
+		IAuthorization authorization = user.createAuthorization("my note", IAuthorization.SCOPE_SESSION, 600);
 		assertNotNull(authorization.getToken());
 
 		// operations
@@ -93,7 +93,7 @@ public class AuthorizationTest extends TestTimer {
 		authorization = connection.getUser().getAuthorization();
 
 		// verifications
-		assertEquals(authorization.getScopes(), IAuthorization.SCOPE_SESSION_READ);
+		assertEquals(authorization.getScopes(), IAuthorization.SCOPE_SESSION);
 		assertEquals(authorization.getNote(), "my note");
 
 		authorization.destroy();
@@ -102,7 +102,7 @@ public class AuthorizationTest extends TestTimer {
 	@Test
 	public void shouldDestroyAuthorization() throws Exception {
 		// pre-conditions
-		IAuthorization authorization = user.createAuthorization("my note", IAuthorization.SCOPE_SESSION_READ, 600);
+		IAuthorization authorization = user.createAuthorization("my note", IAuthorization.SCOPE_READ, 600);
 		assertNotNull(authorization.getToken());
 
 		// operations
@@ -119,7 +119,7 @@ public class AuthorizationTest extends TestTimer {
 	@Test
 	public void shouldCreateNewAuthorization() throws Exception {
 		// pre-conditions
-		IAuthorization authorization = user.createAuthorization("my note", IAuthorization.SCOPE_SESSION_READ, 600);
+		IAuthorization authorization = user.createAuthorization("my note", IAuthorization.SCOPE_READ, 600);
 		assertNotNull(authorization.getToken());
 
 		// operations


### PR DESCRIPTION
Defined session, read, and userinfo scopes. Added unit test to check
scope permissions and expired token
Modified to use 'expires_in_seconds' which returns the remaining time
for the authorization.
