### PR TITLE
Add Maven Central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-OpenShift Java Client
+OpenShift Java Client [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.openshift/openshift-java-client/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.openshift/openshift-java-client)
 ===========================
 
 Java client for the OpenShift REST API.  It pretty much offers all features that are currently available in the rhc-* command line tools 


### PR DESCRIPTION
Add Maven Central badge which makes it easier to get (just after a click) a ready to copy-paste code snippet to put into Maven/Gradle/Sbt/other build configuration file.