### PR TITLE
cleanups: corrected imports, typos, method names

### DIFF
--- a/src/main/java/com/openshift/client/ConnectionBuilder.java
+++ b/src/main/java/com/openshift/client/ConnectionBuilder.java
@@ -234,12 +234,12 @@ public class ConnectionBuilder {
 
 		public IHttpClient createHttpClient(final String clientId, final String username, final String password,
 				final String authKey, final String authIV, final String token, final String serverUrl,
-				final int timeout, final ISSLCertificateCallback sslCertificateCallback, String exludeSSLCipherRegex) {
+				final int timeout, final ISSLCertificateCallback sslCertificateCallback, String excludeSSLCipherRegex) {
 			return new UrlConnectionHttpClientBuilder()
 					.setCredentials(username, password, authKey, authIV, token)
 					.setConfigTimeout(timeout)
 					.setSSLCertificateCallback(sslCertificateCallback)
-					.excludeSSLCipher(exludeSSLCipherRegex)
+					.excludeSSLCipher(excludeSSLCipherRegex)
 					.client();
 		}
 

--- a/src/main/java/com/openshift/client/IApplication.java
+++ b/src/main/java/com/openshift/client/IApplication.java
@@ -413,9 +413,9 @@ public interface IApplication extends IOpenShiftResource {
 	 * @return true if the port-forwarding has been started, false otherwise.
 	 * @throws OpenShiftSSHOperationException
 	 *
-	 * @deprecated use {@link IApplicationSSHSession#isPortFowardingStarted()}
+	 * @deprecated use {@link IApplicationSSHSession#isPortForwardingStarted()}
 	 */
-	public boolean isPortFowardingStarted() throws OpenShiftSSHOperationException;
+	public boolean isPortForwardingStarted() throws OpenShiftSSHOperationException;
 
 	/**
 	 * Returns the list of forwardable ports on OpenShift for this application.

--- a/src/main/java/com/openshift/client/IApplicationSSHSession.java
+++ b/src/main/java/com/openshift/client/IApplicationSSHSession.java
@@ -88,7 +88,7 @@ public interface IApplicationSSHSession {
 	 * @return true if the port-forwarding has been started, false otherwise.
 	 * @throws OpenShiftSSHOperationException
 	 */
-	public boolean isPortFowardingStarted() throws OpenShiftSSHOperationException;
+	public boolean isPortForwardingStarted() throws OpenShiftSSHOperationException;
 
 
 }

--- a/src/main/java/com/openshift/client/IOpenShiftResource.java
+++ b/src/main/java/com/openshift/client/IOpenShiftResource.java
@@ -9,7 +9,7 @@ public interface IOpenShiftResource {
 	 * Creation logs are only available at creation time. So resources that were retrieved 
 	 * while they already existed wont have a creation log.
 	 * 
-	 * @return true if there's cretion log for this resource
+	 * @return true if there's creation log for this resource
 	 */
 	public boolean hasCreationLog();
 
@@ -23,7 +23,7 @@ public interface IOpenShiftResource {
 	/**
 	 * Returns all the (creation log) messages. These messages only exist at
 	 * creation time. Existing cartridges, that were added in a prior session
-	 * dont have any messages any more.
+	 * don't have any messages any more.
 	 * 
 	 * @return all messages by field
 	 * 

--- a/src/main/java/com/openshift/client/IUser.java
+++ b/src/main/java/com/openshift/client/IUser.java
@@ -134,14 +134,14 @@ public interface IUser extends IOpenShiftResource {
 	 */
 	public IOpenShiftSSHKey addSSHKey(String name, ISSHPublicKey key) throws OpenShiftException;
 
-	public IOpenShiftSSHKey getSSHKeyByName(String name) throws OpenShiftUnknonwSSHKeyTypeException, OpenShiftException;
+	public IOpenShiftSSHKey getSSHKeyByName(String name) throws OpenShiftUnknownSSHKeyTypeException, OpenShiftException;
 
-	public IOpenShiftSSHKey getSSHKeyByPublicKey(String publicKey) throws OpenShiftUnknonwSSHKeyTypeException,
+	public IOpenShiftSSHKey getSSHKeyByPublicKey(String publicKey) throws OpenShiftUnknownSSHKeyTypeException,
 			OpenShiftException;
 
-	public boolean hasSSHKeyName(String name) throws OpenShiftUnknonwSSHKeyTypeException, OpenShiftException;
+	public boolean hasSSHKeyName(String name) throws OpenShiftUnknownSSHKeyTypeException, OpenShiftException;
 
-	public boolean hasSSHPublicKey(String publicKey) throws OpenShiftUnknonwSSHKeyTypeException, OpenShiftException;
+	public boolean hasSSHPublicKey(String publicKey) throws OpenShiftUnknownSSHKeyTypeException, OpenShiftException;
 
 	public boolean removeSSHKey(String name);
 

--- a/src/main/java/com/openshift/client/OpenShiftConnectionFactory.java
+++ b/src/main/java/com/openshift/client/OpenShiftConnectionFactory.java
@@ -158,7 +158,7 @@ public class OpenShiftConnectionFactory extends AbstractOpenShiftConnectionFacto
 	 */
 	public IOpenShiftConnection getConnection(final String clientId, final String username, final String password,
 			final String authKey, final String authIV, final String token, final String serverUrl,
-			final ISSLCertificateCallback sslCertificateCallback, String exludeSSLCipherRegex)
+			final ISSLCertificateCallback sslCertificateCallback, String excludeSSLCipherRegex)
 			throws OpenShiftException {
 
 		Assert.notNull(clientId);
@@ -170,7 +170,7 @@ public class OpenShiftConnectionFactory extends AbstractOpenShiftConnectionFacto
 
 		IHttpClient httpClient = createClient(
 				clientId, username, password, authKey, authIV, token, serverUrl, sslCertificateCallback,
-				exludeSSLCipherRegex);
+				excludeSSLCipherRegex);
 		try {
 			return getConnection(clientId, username, password, token, serverUrl, httpClient);
 		} catch (IOException e) {

--- a/src/main/java/com/openshift/client/OpenShiftUnknownSSHKeyTypeException.java
+++ b/src/main/java/com/openshift/client/OpenShiftUnknownSSHKeyTypeException.java
@@ -13,11 +13,11 @@ package com.openshift.client;
 /**
  * @author Andre Dietisheim
  */
-public class OpenShiftUnknonwSSHKeyTypeException  extends OpenShiftException {
+public class OpenShiftUnknownSSHKeyTypeException extends OpenShiftException {
 
 	private static final long serialVersionUID = 1L;
 
-	public OpenShiftUnknonwSSHKeyTypeException(String message, Object... arguments) {
+	public OpenShiftUnknownSSHKeyTypeException(String message, Object... arguments) {
 		super(message, arguments);
 	}
 }

--- a/src/main/java/com/openshift/client/SSHKeyType.java
+++ b/src/main/java/com/openshift/client/SSHKeyType.java
@@ -49,7 +49,7 @@ public enum SSHKeyType {
 		}
 	}
 
-	public static SSHKeyType getByTypeId(String keyTypeId) throws OpenShiftUnknonwSSHKeyTypeException {
+	public static SSHKeyType getByTypeId(String keyTypeId) throws OpenShiftUnknownSSHKeyTypeException {
 		Assert.notNull(keyTypeId);
 
 		for (SSHKeyType sSHKeyType : values()) {
@@ -57,22 +57,22 @@ public enum SSHKeyType {
 				return sSHKeyType;
 			}
 		}
-		throw new OpenShiftUnknonwSSHKeyTypeException("OpenShift does not support keys of type \"{0}\"", keyTypeId);
+		throw new OpenShiftUnknownSSHKeyTypeException("OpenShift does not support keys of type \"{0}\"", keyTypeId);
 	}
 
-	public static SSHKeyType getByJSchKeyType(KeyPair keyPair) throws OpenShiftUnknonwSSHKeyTypeException {
+	public static SSHKeyType getByJSchKeyType(KeyPair keyPair) throws OpenShiftUnknownSSHKeyTypeException {
 		Assert.notNull(keyPair);
 
 		return getByJSchKeyType(keyPair.getKeyType());
 	}
 
-	public static SSHKeyType getByJSchKeyType(int jschKeyType) throws OpenShiftUnknonwSSHKeyTypeException {
+	public static SSHKeyType getByJSchKeyType(int jschKeyType) throws OpenShiftUnknownSSHKeyTypeException {
 		if (jschKeyType == KeyPair.RSA) {
 			return SSH_RSA;
 		} else if (jschKeyType == KeyPair.DSA) {
 			return SSH_DSA;
 		} else {
-			throw new OpenShiftUnknonwSSHKeyTypeException("Unknown jsch key type \"{0}\"", jschKeyType);
+			throw new OpenShiftUnknownSSHKeyTypeException("Unknown jsch key type \"{0}\"", jschKeyType);
 		}
 	}
 }

--- a/src/main/java/com/openshift/client/cartridge/StandaloneCartridge.java
+++ b/src/main/java/com/openshift/client/cartridge/StandaloneCartridge.java
@@ -19,7 +19,7 @@ import com.openshift.internal.client.cartridge.BaseCartridge;
 
 /**
  * A cartridge that is available on the openshift server. This class is no enum
- * since we dont know all available types and they may change at any time.
+ * since we don't know all available types and they may change at any time.
  * 
  * @author André Dietisheim
  * @author Jeff Cantrill

--- a/src/main/java/com/openshift/client/cartridge/query/CartridgeNameQuery.java
+++ b/src/main/java/com/openshift/client/cartridge/query/CartridgeNameQuery.java
@@ -33,7 +33,7 @@ public class CartridgeNameQuery extends AbstractCartridgeQuery {
 				|| cartridge.getName() == null) {
 			return false;
 		}
-		return cartridge.getName().indexOf(nameSubstring) >= 0;
+		return cartridge.getName().contains(nameSubstring);
 	}
 
 	@Override

--- a/src/main/java/com/openshift/client/cartridge/query/LatestEmbeddableCartridge.java
+++ b/src/main/java/com/openshift/client/cartridge/query/LatestEmbeddableCartridge.java
@@ -20,7 +20,7 @@ import com.openshift.client.cartridge.IEmbeddableCartridge;
 import com.openshift.internal.client.utils.Assert;
 
 /**
- * A query that shall select the latest version of an embedded cartidge that's given by name.
+ * A query that shall select the latest version of an embedded cartridge that's given by name.
  * 
  * @author Andre Dietisheim
  * 

--- a/src/main/java/com/openshift/client/cartridge/query/LatestStandaloneCartridge.java
+++ b/src/main/java/com/openshift/client/cartridge/query/LatestStandaloneCartridge.java
@@ -18,7 +18,7 @@ import com.openshift.client.cartridge.IStandaloneCartridge;
 import com.openshift.internal.client.utils.Assert;
 
 /**
- * A query that shall select the latest version of a standalone cartidge that's given by name.
+ * A query that shall select the latest version of a standalone cartridge that's given by name.
  * 
  * @author Andre Dietisheim
  * 

--- a/src/main/java/com/openshift/client/utils/RFC822DateUtils.java
+++ b/src/main/java/com/openshift/client/utils/RFC822DateUtils.java
@@ -45,7 +45,7 @@ public class RFC822DateUtils {
 
 	/**
 	 * Returns a date instance for a given timestamp string that complies to the
-	 * RFC 822 standard. If an error occurrs, <code>null</code> is returned an
+	 * RFC 822 standard. If an error occurs, <code>null</code> is returned an
 	 * no exception is thrown.
 	 * 
 	 * @param rfc822DateString

--- a/src/main/java/com/openshift/internal/client/ApplicationResource.java
+++ b/src/main/java/com/openshift/internal/client/ApplicationResource.java
@@ -648,7 +648,7 @@ public class ApplicationResource extends AbstractOpenShiftResource implements IA
 		return this.session != null && this.session.isConnected();
 	}
 
-	public boolean isPortFowardingStarted() throws OpenShiftSSHOperationException {
+	public boolean isPortForwardingStarted() throws OpenShiftSSHOperationException {
 		try {
 			return this.session != null && this.session.isConnected() && this.session.getPortForwardingL().length > 0;
 		} catch (JSchException e) {

--- a/src/main/java/com/openshift/internal/client/ApplicationSSHSession.java
+++ b/src/main/java/com/openshift/internal/client/ApplicationSSHSession.java
@@ -108,7 +108,7 @@ public class ApplicationSSHSession implements IApplicationSSHSession {
 	 * @return true if port forwarding is started, false otherwise
 	 * @throws OpenShiftSSHOperationException
 	 */
-	public boolean isPortFowardingStarted() throws OpenShiftSSHOperationException {
+	public boolean isPortForwardingStarted() throws OpenShiftSSHOperationException {
 		try {
 			return isConnected()
 					&& session.getPortForwardingL().length > 0;
@@ -326,7 +326,7 @@ public class ApplicationSSHSession implements IApplicationSSHSession {
 			return false;
 		} else if (isConnected() != other.isConnected()) {
 			return false;
-		} else if (isPortFowardingStarted() != other.isPortFowardingStarted()) {
+		} else if (isPortForwardingStarted() != other.isPortForwardingStarted()) {
 			return false;
 		} else if (!application.equals(otherapp)) {
 			return false;
@@ -340,7 +340,7 @@ public class ApplicationSSHSession implements IApplicationSSHSession {
 				+ "applicationuuid=" + application.getUUID()
 				+ ", applicationname=" + application.getName()
 				+ ", isconnected=" + isConnected()
-				+ ", isportforwardingstarted=" + isPortFowardingStarted()
+				+ ", isportforwardingstarted=" + isPortForwardingStarted()
 				+ "]";
 	}
 

--- a/src/main/java/com/openshift/internal/client/GearGroupResource.java
+++ b/src/main/java/com/openshift/internal/client/GearGroupResource.java
@@ -84,7 +84,7 @@ public class GearGroupResource extends AbstractOpenShiftResource implements IGea
 	 * 
 	 * @param dto the associated {@link GearGroupResourceDTO} 
 	 * @param application the parent application 
-	 * @param servicethe underlying REST Service
+	 * @param service the underlying REST Service
 	 */
 	protected GearGroupResource(final GearGroupResourceDTO dto, final ApplicationResource application, final IRestService service) {
 		this(dto.getUuid(), dto.getName(), dto.getGears(), dto.getCartridges(), dto.getAdditionalStorage(), application, service);

--- a/src/main/java/com/openshift/internal/client/IRestService.java
+++ b/src/main/java/com/openshift/internal/client/IRestService.java
@@ -59,7 +59,7 @@ public interface IRestService {
 	 * @param urlParameters
 	 *            the url parameters ("?parameter=value")
 	 * @param parameters
-	 *            the body parameters (ingnored for GET requests)
+	 *            the body parameters (ignored for GET requests)
 	 * @param parameters
 	 *            the parameters to send
 	 * @return the rest response

--- a/src/main/java/com/openshift/internal/client/SSHKeyResource.java
+++ b/src/main/java/com/openshift/internal/client/SSHKeyResource.java
@@ -12,7 +12,7 @@ package com.openshift.internal.client;
 
 import com.openshift.client.IOpenShiftSSHKey;
 import com.openshift.client.OpenShiftException;
-import com.openshift.client.OpenShiftUnknonwSSHKeyTypeException;
+import com.openshift.client.OpenShiftUnknownSSHKeyTypeException;
 import com.openshift.client.SSHKeyType;
 import com.openshift.internal.client.httpclient.request.StringParameter;
 import com.openshift.internal.client.response.KeyResourceDTO;
@@ -29,7 +29,7 @@ public class SSHKeyResource extends AbstractOpenShiftResource implements IOpenSh
 	private String publicKey;
 	private UserResource user;
 
-	protected SSHKeyResource(KeyResourceDTO dto, UserResource user) throws OpenShiftUnknonwSSHKeyTypeException {
+	protected SSHKeyResource(KeyResourceDTO dto, UserResource user) throws OpenShiftUnknownSSHKeyTypeException {
 		super(user.getService(), dto.getLinks(), dto.getMessages());
 		this.name = dto.getName();
 		this.type = SSHKeyType.getByTypeId(dto.getType());
@@ -77,7 +77,7 @@ public class SSHKeyResource extends AbstractOpenShiftResource implements IOpenSh
 		this.publicKey = null;
 	}
 	
-	protected void update(KeyResourceDTO dto) throws OpenShiftUnknonwSSHKeyTypeException {
+	protected void update(KeyResourceDTO dto) throws OpenShiftUnknownSSHKeyTypeException {
 		if (dto == null) {
 			return;
 		}

--- a/src/main/java/com/openshift/internal/client/UserResource.java
+++ b/src/main/java/com/openshift/internal/client/UserResource.java
@@ -22,7 +22,7 @@ import com.openshift.client.ISSHPublicKey;
 import com.openshift.client.IUser;
 import com.openshift.client.OpenShiftException;
 import com.openshift.client.OpenShiftSSHKeyException;
-import com.openshift.client.OpenShiftUnknonwSSHKeyTypeException;
+import com.openshift.client.OpenShiftUnknownSSHKeyTypeException;
 import com.openshift.client.SSHKeyType;
 import com.openshift.client.IAuthorization;
 import com.openshift.internal.client.httpclient.request.StringParameter;
@@ -180,7 +180,7 @@ public class UserResource extends AbstractOpenShiftResource implements IUser {
 	}
 
 	@Override
-	public List<IOpenShiftSSHKey> getSSHKeys() throws OpenShiftUnknonwSSHKeyTypeException,
+	public List<IOpenShiftSSHKey> getSSHKeys() throws OpenShiftUnknownSSHKeyTypeException,
 			OpenShiftException {
 		Map<String, IOpenShiftSSHKey> keys = new HashMap<String, IOpenShiftSSHKey>();
 		keys.putAll(getCachedOrLoadSSHKeys());
@@ -188,7 +188,7 @@ public class UserResource extends AbstractOpenShiftResource implements IUser {
 	}
 
 	private Map<String, SSHKeyResource> getCachedOrLoadSSHKeys() throws OpenShiftException,
-			OpenShiftUnknonwSSHKeyTypeException {
+			OpenShiftUnknownSSHKeyTypeException {
 		if (sshKeys == null) {
 			this.sshKeys = loadKeys();
 		}
@@ -196,7 +196,7 @@ public class UserResource extends AbstractOpenShiftResource implements IUser {
 	}
 
 	private Map<String, SSHKeyResource> loadKeys() throws OpenShiftException,
-			OpenShiftUnknonwSSHKeyTypeException {
+			OpenShiftUnknownSSHKeyTypeException {
 		Map<String, SSHKeyResource> keys = new HashMap<String, SSHKeyResource>();
 		List<KeyResourceDTO> keyDTOs = new GetSShKeysRequest().execute();
 		for (KeyResourceDTO keyDTO : keyDTOs) {
@@ -224,7 +224,7 @@ public class UserResource extends AbstractOpenShiftResource implements IUser {
 	
 	@Override
 	public IOpenShiftSSHKey getSSHKeyByName(String name) 
-			throws OpenShiftUnknonwSSHKeyTypeException, OpenShiftException {
+			throws OpenShiftUnknownSSHKeyTypeException, OpenShiftException {
 		Assert.notNull(name);
 
 		return getCachedOrLoadSSHKeys().get(name);
@@ -232,7 +232,7 @@ public class UserResource extends AbstractOpenShiftResource implements IUser {
 
 	@Override
 	public IOpenShiftSSHKey getSSHKeyByPublicKey(String publicKey)
-			throws OpenShiftUnknonwSSHKeyTypeException, OpenShiftException {
+			throws OpenShiftUnknownSSHKeyTypeException, OpenShiftException {
 		Assert.notNull(publicKey);
 
 		IOpenShiftSSHKey matchingKey = null;
@@ -250,7 +250,7 @@ public class UserResource extends AbstractOpenShiftResource implements IUser {
 	}
 
 	@Override
-	public boolean hasSSHKeyName(String name) throws OpenShiftUnknonwSSHKeyTypeException,
+	public boolean hasSSHKeyName(String name) throws OpenShiftUnknownSSHKeyTypeException,
 			OpenShiftException {
 		Assert.notNull(name);
 
@@ -259,7 +259,7 @@ public class UserResource extends AbstractOpenShiftResource implements IUser {
 
 	@Override
 	public boolean hasSSHPublicKey(String publicKey)
-			throws OpenShiftUnknonwSSHKeyTypeException, OpenShiftException {
+			throws OpenShiftUnknownSSHKeyTypeException, OpenShiftException {
 		return getSSHKeyByPublicKey(publicKey) != null;
 	}
 
@@ -291,7 +291,7 @@ public class UserResource extends AbstractOpenShiftResource implements IUser {
 		return put(keyDTO);
 	}
 
-	private SSHKeyResource put(KeyResourceDTO keyDTO) throws OpenShiftUnknonwSSHKeyTypeException {
+	private SSHKeyResource put(KeyResourceDTO keyDTO) throws OpenShiftUnknownSSHKeyTypeException {
 		SSHKeyResource sshKey = new SSHKeyResource(keyDTO, this);
 		getCachedOrLoadSSHKeys().put(keyDTO.getName(), sshKey);
 		return sshKey;

--- a/src/main/java/com/openshift/internal/client/httpclient/UrlConnectionHttpClient.java
+++ b/src/main/java/com/openshift/internal/client/httpclient/UrlConnectionHttpClient.java
@@ -305,7 +305,7 @@ public class UrlConnectionHttpClient implements IHttpClient {
 			connection.setSSLSocketFactory(sslContext.getSocketFactory());
 			return sslContext;
 		} catch (GeneralSecurityException e) {
-			LOGGER.warn("Could not install trust manager callback", e);;
+			LOGGER.warn("Could not install trust manager callback", e);
 			return null;
 		}
 	}
@@ -325,7 +325,7 @@ public class UrlConnectionHttpClient implements IHttpClient {
 				trustManager = new CallbackTrustManager(trustManager, sslAuthorizationCallback);
 			}
 		} catch (GeneralSecurityException e) {
-			LOGGER.warn("Could not install trust manager callback.", e);;
+			LOGGER.warn("Could not install trust manager callback.", e);
 		}
 		return trustManager;
 	}

--- a/src/main/java/com/openshift/internal/client/httpclient/request/FormUrlEncodedMediaType.java
+++ b/src/main/java/com/openshift/internal/client/httpclient/request/FormUrlEncodedMediaType.java
@@ -113,7 +113,7 @@ public class FormUrlEncodedMediaType implements IMediaType {
 
 	private String encode(String value) throws UnsupportedEncodingException {
 		if (UrlUtils.isUrl(value)) {
-			// dont encode url payload
+			// don't encode url payload
 			return value;
 		}
 		return URLEncoder.encode(value, UTF8);

--- a/src/main/java/com/openshift/internal/client/httpclient/request/ParameterValueMap.java
+++ b/src/main/java/com/openshift/internal/client/httpclient/request/ParameterValueMap.java
@@ -57,7 +57,7 @@ public class ParameterValueMap extends ParameterValue<Map<String, Parameter>> {
 		return this;
 	}
 
-	public Parameter getParamater(String name) {
+	public Parameter getParameter(String name) {
 		return getValue().get(name);
 	}
 	

--- a/src/main/java/com/openshift/internal/client/response/EnumDataType.java
+++ b/src/main/java/com/openshift/internal/client/response/EnumDataType.java
@@ -43,7 +43,7 @@ public enum EnumDataType {
 	cartridge,
 	/** The environment-variables type*/
 	environment_variables,
-	/** The environmetn-variable type*/
+	/** The environment-variable type*/
 	environment_variable
 	;
 	

--- a/src/main/java/com/openshift/internal/client/response/Link.java
+++ b/src/main/java/com/openshift/internal/client/response/Link.java
@@ -181,7 +181,7 @@ public class Link {
 			throw new OpenShiftRequestException("Requesting {0}: required request parameter \"{1}\" is empty",
 					getHref(), linkParameter.getName());
 		}
-		// TODO: check valid options (still reported in a very incosistent way)
+		// TODO: check valid options (still reported in a very inconsistent way)
 	}
 
 	private Parameter getParameter(String name, Parameter[] parameters) {
@@ -257,9 +257,9 @@ public class Link {
 			new FormUrlEncodedMediaType().writeTo(new ParameterValueMap(urlParameters), out);
 			return out.toString();
 		} catch (IOException e) {
-			throw new OpenShiftException(e, "Could not add paramters {0} to url {1}", urlParameters, url);
+			throw new OpenShiftException(e, "Could not add parameters {0} to url {1}", urlParameters, url);
 		} catch (EncodingException e) {
-			throw new OpenShiftException(e, "Could not add paramters {0} to url {1}", urlParameters, url);
+			throw new OpenShiftException(e, "Could not add parameters {0} to url {1}", urlParameters, url);
 		}
 	}
 

--- a/src/main/java/com/openshift/internal/client/ssh/AbstractSSHKey.java
+++ b/src/main/java/com/openshift/internal/client/ssh/AbstractSSHKey.java
@@ -11,7 +11,7 @@
 package com.openshift.internal.client.ssh;
 
 import com.openshift.client.ISSHPublicKey;
-import com.openshift.client.OpenShiftUnknonwSSHKeyTypeException;
+import com.openshift.client.OpenShiftUnknownSSHKeyTypeException;
 import com.openshift.client.SSHKeyType;
 
 /**
@@ -29,7 +29,7 @@ public abstract class AbstractSSHKey implements ISSHPublicKey {
 		return keyType;
 	}
 
-	protected void setKeyType(String keyTypeId) throws OpenShiftUnknonwSSHKeyTypeException {
+	protected void setKeyType(String keyTypeId) throws OpenShiftUnknownSSHKeyTypeException {
 		setKeyType(SSHKeyType.getByTypeId(keyTypeId));
 	}
 

--- a/src/test/java/com/openshift/client/fakes/HttpServerFake.java
+++ b/src/test/java/com/openshift/client/fakes/HttpServerFake.java
@@ -70,9 +70,9 @@ public class HttpServerFake {
 	 * @param port
 	 *            the port to listen to (address is always localhost)
 	 * @param response
-	 *            the reponse to return to the requesting socket. If
+	 *            the response to return to the requesting socket. If
 	 *            <code>null</code> the request string is returned.
-	 * @param statusLine the staus line that shall be returned
+	 * @param statusLine the status line that shall be returned
 	 * 	           
 	 * @see ServerFakeSocket#getResponse(Socket)
 	 */

--- a/src/test/java/com/openshift/client/fakes/HttpsServerFake.java
+++ b/src/test/java/com/openshift/client/fakes/HttpsServerFake.java
@@ -47,10 +47,10 @@ public class HttpsServerFake extends HttpServerFake {
 	 * @param port
 	 *            the port to listen to (address is always localhost)
 	 * @param response
-	 *            the reponse to return to the requesting socket. If
+	 *            the response to return to the requesting socket. If
 	 *            <code>null</code> the request string is returned.
 	 * @param statusLine
-	 *            the staus line that shall be returned
+	 *            the status line that shall be returned
 	 * 
 	 * @see ServerFakeSocket#getResponse(Socket)
 	 */

--- a/src/test/java/com/openshift/client/portforwarding/PortForwardingL.java
+++ b/src/test/java/com/openshift/client/portforwarding/PortForwardingL.java
@@ -55,8 +55,8 @@ public class PortForwardingL{
       //Channel channel=session.openChannel("shell");
       //channel.connect();
 
-      int assinged_port=session.setPortForwardingL(lport, rhost, rport);
-      System.out.println("localhost:"+assinged_port+" -> "+rhost+":"+rport);
+      int assigned_port=session.setPortForwardingL(lport, rhost, rport);
+      System.out.println("localhost:"+assigned_port+" -> "+rhost+":"+rport);
     }
     catch(Exception e){
       System.out.println(e);

--- a/src/test/java/com/openshift/client/utils/ApplicationTestUtils.java
+++ b/src/test/java/com/openshift/client/utils/ApplicationTestUtils.java
@@ -242,7 +242,7 @@ public class ApplicationTestUtils {
 	
 	public static IApplication destroyAllEnvironmentVariables(IApplication application) {
 		for (String name : application.getEnvironmentVariables().keySet()) {
-			application.removeEnvironmentVariable(name);;
+			application.removeEnvironmentVariable(name);
 		}
 		return application;
 	}

--- a/src/test/java/com/openshift/client/utils/EmbeddedCartridgeTestUtils.java
+++ b/src/test/java/com/openshift/client/utils/EmbeddedCartridgeTestUtils.java
@@ -73,7 +73,7 @@ public class EmbeddedCartridgeTestUtils {
 	 * if they aren't they are added.
 	 * 
 	 * @param constraint
-	 *            the constraint that selects the available catridges that
+	 *            the constraint that selects the available cartridges that
 	 *            should be present
 	 * @param application
 	 *            the application that should have the constrained cartridges

--- a/src/test/java/com/openshift/client/utils/GearProfileTestUtils.java
+++ b/src/test/java/com/openshift/client/utils/GearProfileTestUtils.java
@@ -2,7 +2,6 @@ package com.openshift.client.utils;
 
 import com.openshift.client.IDomain;
 import com.openshift.client.IGearProfile;
-import com.openshift.internal.client.GearProfile;
 
 import java.util.List;
 

--- a/src/test/java/com/openshift/internal/client/ApplicationResourceTest.java
+++ b/src/test/java/com/openshift/internal/client/ApplicationResourceTest.java
@@ -617,7 +617,7 @@ public class ApplicationResourceTest extends TestTimer {
 						POST_ADD_ENVIRONMENT_VARIABLE_FOO_TO_FOOBARZ_SPRINGEAP6)
 				.mockGetEnvironmentVariables("foobarz", "springeap6", GET_0_ENVIRONMENT_VARIABLES_FOOBARZ_SPRINGEAP6,
 						GET_1_ENVIRONMENT_VARIABLES_FOOBARZ_SPRINGEAP6)
-				.mockUpdateEnvironmentVariableValue("foobarz", "springeap6", "FOO", PUT_FOO_ENVIRONMENT_VARIABLE_FOOBARZ_SPRINGEAP6);;
+				.mockUpdateEnvironmentVariableValue("foobarz", "springeap6", "FOO", PUT_FOO_ENVIRONMENT_VARIABLE_FOOBARZ_SPRINGEAP6);
 
 		// operation
 		final IApplication app = domain.getApplicationByName("springeap6");

--- a/src/test/java/com/openshift/internal/client/DomainResourceIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/client/DomainResourceIntegrationTest.java
@@ -108,7 +108,7 @@ public class DomainResourceIntegrationTest extends TestTimer {
 			// operation
 			domain.destroy();
 			// verification
-			fail("OpenShiftEndpointException did not occurr");
+			fail("OpenShiftEndpointException did not occur");
 		} catch (OpenShiftEndpointException e) {
 			// verification
 		}
@@ -125,7 +125,7 @@ public class DomainResourceIntegrationTest extends TestTimer {
 			
 			// operation
 			domain.destroy();
-			fail("OpenShiftEndpointException did not occurr");
+			fail("OpenShiftEndpointException did not occur");
 		} catch (OpenShiftEndpointException e) {
 			// verification
 			assertThat(e.getRestResponseMessages().size()).isEqualTo(1);

--- a/src/test/java/com/openshift/internal/client/EmbeddableCartridgeTest.java
+++ b/src/test/java/com/openshift/internal/client/EmbeddableCartridgeTest.java
@@ -48,7 +48,7 @@ public class EmbeddableCartridgeTest extends TestTimer {
 
 	@Test
 	public void shouldNonDownloadableEqualsNonDownloadable() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertThat(new EmbeddableCartridge("redhat"))
@@ -59,7 +59,7 @@ public class EmbeddableCartridgeTest extends TestTimer {
 
 	@Test
 	public void shouldDownloadableEqualsDownloadable() throws MalformedURLException {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertThat(new EmbeddableCartridge(new URL(CartridgeTestUtils.FOREMAN_URL)))
@@ -68,12 +68,12 @@ public class EmbeddableCartridgeTest extends TestTimer {
 
 	@Test
 	public void shouldDownloadableWithNonEqualNameEqualsDownloadable() throws MalformedURLException {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertThat(new EmbeddableCartridge("redhat", new URL(CartridgeTestUtils.FOREMAN_URL)))
 				.isEqualTo(new EmbeddableCartridge(null, new URL(CartridgeTestUtils.FOREMAN_URL)));
-		// should equal if url is equal, name doesnt matter
+		// should equal if url is equal, name doesn't matter
 		// (name is updated as soon as cartridge is deployed)
 		assertThat(new EmbeddableCartridge("jboss", new URL(CartridgeTestUtils.FOREMAN_URL)))
 				.isEqualTo(new EmbeddableCartridge("redhat", new URL(CartridgeTestUtils.FOREMAN_URL)));
@@ -81,7 +81,7 @@ public class EmbeddableCartridgeTest extends TestTimer {
 
 	@Test
 	public void shouldDownloadableStandaloneNotEqualsDownloadableEmbeddable() throws MalformedURLException {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertThat(new EmbeddableCartridge(null, new URL(CartridgeTestUtils.FOREMAN_URL)))
@@ -89,13 +89,13 @@ public class EmbeddableCartridgeTest extends TestTimer {
 	}
 
 	@Test
-	public void shouldHaveNameDisplaynameDescription() throws Throwable {
+	public void shouldHaveNameDisplayNameDescription() throws Throwable {
 		// pre-condition
 		IEmbeddableCartridge mongoDb = connection.getEmbeddableCartridges().get(0);
 		CartridgeAssert<IEmbeddableCartridge> cartridgeAssert = new CartridgeAssert<IEmbeddableCartridge>(mongoDb);
 
 		// operation
-		// verifcation
+		// verification
 		cartridgeAssert
 				.hasName("mongodb-2.2")
 				.hasDisplayName("MongoDB NoSQL Database 2.2")
@@ -104,7 +104,7 @@ public class EmbeddableCartridgeTest extends TestTimer {
 
 	@Test
 	public void shouldHaveObsoleteCartridges() throws MalformedURLException {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		ICartridge metrics = new CartridgeNameQuery("metrics").get(connection.getCartridges(true));
 		assertThat(metrics).isNotNull();

--- a/src/test/java/com/openshift/internal/client/EmbeddedCartridgeResourceIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/client/EmbeddedCartridgeResourceIntegrationTest.java
@@ -87,7 +87,7 @@ public class EmbeddedCartridgeResourceIntegrationTest extends TestTimer {
 					}
 					if (php.getName().equals(((ICartridge)value).getName())) {
 						return true;
-					};
+					}
 				}
 				return false;
 			}

--- a/src/test/java/com/openshift/internal/client/EmbeddedCartridgeResourceTest.java
+++ b/src/test/java/com/openshift/internal/client/EmbeddedCartridgeResourceTest.java
@@ -73,7 +73,7 @@ public class EmbeddedCartridgeResourceTest extends TestTimer {
 
 	@Test
 	public void shouldEmbeddedCartridgeEqualsEmbeddableCartridge() {
-		// pre-coniditions
+		// pre-conditions
 		IEmbeddedCartridge embeddedCartridgeFake = createEmbeddedCartridgeFake("redhat");
 
 		// operation
@@ -85,7 +85,7 @@ public class EmbeddedCartridgeResourceTest extends TestTimer {
 
 	@Test
 	public void shouldHaveSameHashCode() {
-		// pre-coniditions
+		// pre-conditions
 		IEmbeddedCartridge embeddedCartridgeFake = createEmbeddedCartridgeFake("redhat");
 		// operation
 		// verification
@@ -94,7 +94,7 @@ public class EmbeddedCartridgeResourceTest extends TestTimer {
 	
 	@Test
 	public void shouldEmbeddableCartridgeWithNameEqualsEmbeddedCartridgeWithoutName() throws MalformedURLException {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertEquals(new EmbeddableCartridge(null, new URL(CartridgeTestUtils.FOREMAN_URL)),
@@ -103,7 +103,7 @@ public class EmbeddedCartridgeResourceTest extends TestTimer {
 
 	@Test
 	public void shouldRemoveEmbeddedCartridgeInASetByEmbeddableCartridge() {
-		// pre-coniditions
+		// pre-conditions
 		IEmbeddedCartridge embeddedCartridgeMock = createEmbeddedCartridgeFake("redhat");
 		HashSet<IEmbeddedCartridge> cartridges = new HashSet<IEmbeddedCartridge>();
 		cartridges.add(embeddedCartridgeMock);

--- a/src/test/java/com/openshift/internal/client/LatestVersionQueryIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/client/LatestVersionQueryIntegrationTest.java
@@ -39,7 +39,7 @@ public class LatestVersionQueryIntegrationTest extends TestTimer {
 
 	@Test
 	public void shouldSelectJBossAs() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertCartridge(IStandaloneCartridge.NAME_JBOSSAS, LatestVersionOf.jbossAs().get(user)); 
@@ -47,7 +47,7 @@ public class LatestVersionQueryIntegrationTest extends TestTimer {
 
 	@Test
 	public void shouldSelectJBossEap() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertCartridge(IStandaloneCartridge.NAME_JBOSSEAP, LatestVersionOf.jbossEap().get(user)); 
@@ -55,7 +55,7 @@ public class LatestVersionQueryIntegrationTest extends TestTimer {
 
 	@Test
 	public void shouldSelectJBossEws() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertCartridge(IStandaloneCartridge.NAME_JBOSSEWS, LatestVersionOf.jbossEws().get(user)); 
@@ -63,7 +63,7 @@ public class LatestVersionQueryIntegrationTest extends TestTimer {
 
 	@Test
 	public void shouldSelectJenkins() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertCartridge(IStandaloneCartridge.NAME_JENKINS, LatestVersionOf.jenkins().get(user)); 
@@ -71,7 +71,7 @@ public class LatestVersionQueryIntegrationTest extends TestTimer {
 
 	@Test
 	public void shouldSelectPerl() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertCartridge(IStandaloneCartridge.NAME_PERL, LatestVersionOf.perl().get(user)); 
@@ -79,7 +79,7 @@ public class LatestVersionQueryIntegrationTest extends TestTimer {
 
 	@Test
 	public void shouldSelectPhp() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertCartridge(IStandaloneCartridge.NAME_PHP, LatestVersionOf.php().get(user)); 
@@ -87,7 +87,7 @@ public class LatestVersionQueryIntegrationTest extends TestTimer {
 
 	@Test
 	public void shouldSelectPython() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertCartridge(IStandaloneCartridge.NAME_PYTHON, LatestVersionOf.python().get(user)); 
@@ -95,7 +95,7 @@ public class LatestVersionQueryIntegrationTest extends TestTimer {
 
 	@Test
 	public void shouldSelectRuby() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertCartridge(IStandaloneCartridge.NAME_RUBY, LatestVersionOf.ruby().get(user)); 
@@ -103,7 +103,7 @@ public class LatestVersionQueryIntegrationTest extends TestTimer {
 
 	@Test
 	public void shouldSelectZend() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertCartridge(IStandaloneCartridge.NAME_ZEND, LatestVersionOf.zend().get(user)); 
@@ -111,7 +111,7 @@ public class LatestVersionQueryIntegrationTest extends TestTimer {
 
 	@Test
 	public void shouldSelectMmsAgent() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertCartridge(IEmbeddedCartridge.NAME_10GEN_MMS_AGENT, LatestVersionOf.mmsAgent().get(user)); 
@@ -120,7 +120,7 @@ public class LatestVersionQueryIntegrationTest extends TestTimer {
 	
 	@Test
 	public void shouldSelectHaProxy() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertCartridge(IEmbeddedCartridge.NAME_HAPROXY, LatestVersionOf.haProxy().get(user)); 
@@ -128,7 +128,7 @@ public class LatestVersionQueryIntegrationTest extends TestTimer {
 
 	@Test
 	public void shouldSelectJenkinsClient() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertCartridge(IEmbeddedCartridge.NAME_JENKINS_CLIENT, LatestVersionOf.jenkinsClient().get(user)); 
@@ -136,7 +136,7 @@ public class LatestVersionQueryIntegrationTest extends TestTimer {
 
 	@Test
 	public void shouldSelectMongoDb() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertCartridge(IEmbeddedCartridge.NAME_MONGODB, LatestVersionOf.mongoDB().get(user)); 
@@ -144,7 +144,7 @@ public class LatestVersionQueryIntegrationTest extends TestTimer {
 
 	@Test
 	public void shouldSelectMySql() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertCartridge(IEmbeddedCartridge.NAME_MYSQL, LatestVersionOf.mySQL().get(user)); 
@@ -152,7 +152,7 @@ public class LatestVersionQueryIntegrationTest extends TestTimer {
 
 	@Test
 	public void shouldSelectPhpMyAdmin() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertCartridge(IEmbeddedCartridge.NAME_PHPMYADMIN, LatestVersionOf.phpMyAdmin().get(user)); 
@@ -160,7 +160,7 @@ public class LatestVersionQueryIntegrationTest extends TestTimer {
 
 	@Test
 	public void shouldSelectpostgreSql() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertCartridge(IEmbeddedCartridge.NAME_POSTGRESQL, LatestVersionOf.postgreSQL().get(user)); 
@@ -168,7 +168,7 @@ public class LatestVersionQueryIntegrationTest extends TestTimer {
 
 	@Test
 	public void shouldSelectRockmongo() {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertCartridge(IEmbeddedCartridge.NAME_ROCKMONGO, LatestVersionOf.rockMongo().get(user)); 

--- a/src/test/java/com/openshift/internal/client/SSHKeyTest.java
+++ b/src/test/java/com/openshift/internal/client/SSHKeyTest.java
@@ -29,7 +29,7 @@ import com.openshift.client.IOpenShiftSSHKey;
 import com.openshift.client.ISSHPublicKey;
 import com.openshift.client.IUser;
 import com.openshift.client.OpenShiftSSHKeyException;
-import com.openshift.client.OpenShiftUnknonwSSHKeyTypeException;
+import com.openshift.client.OpenShiftUnknownSSHKeyTypeException;
 import com.openshift.client.SSHKeyPair;
 import com.openshift.client.SSHKeyType;
 import com.openshift.client.SSHPublicKey;
@@ -164,13 +164,13 @@ public class SSHKeyTest extends TestTimer {
 	}
 
 	@Test
-	public void shouldGetKeyTypeByTypeId() throws OpenShiftUnknonwSSHKeyTypeException {
+	public void shouldGetKeyTypeByTypeId() throws OpenShiftUnknownSSHKeyTypeException {
 		assertTrue(SSHKeyType.SSH_DSA == SSHKeyType.getByTypeId(SSHKeyTestUtils.SSH_DSA));
 		assertTrue(SSHKeyType.SSH_RSA == SSHKeyType.getByTypeId(SSHKeyTestUtils.SSH_RSA));
 	}
 
-	@Test(expected = OpenShiftUnknonwSSHKeyTypeException.class)
-	public void getKeyTypeByTypeIdReturnsNullIfNoMatchingType() throws OpenShiftUnknonwSSHKeyTypeException {
+	@Test(expected = OpenShiftUnknownSSHKeyTypeException.class)
+	public void getKeyTypeByTypeIdReturnsNullIfNoMatchingType() throws OpenShiftUnknownSSHKeyTypeException {
 		SSHKeyType.getByTypeId("dummy");
 	}
 

--- a/src/test/java/com/openshift/internal/client/StandaloneCartridgeResourceIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/client/StandaloneCartridgeResourceIntegrationTest.java
@@ -88,7 +88,7 @@ public class StandaloneCartridgeResourceIntegrationTest extends TestTimer {
 		int additionalGearStorage = cartridge.getAdditionalGearStorage();
 
 		// verification
-		// reload user info to ensure the storage info isnt cached
+		// reload user info to ensure the storage info isn't cached
 		assertThat(additionalGearStorage).isNotEqualTo(IGearGroup.NO_ADDITIONAL_GEAR_STORAGE);
 	}
 
@@ -104,7 +104,7 @@ public class StandaloneCartridgeResourceIntegrationTest extends TestTimer {
 		cartridge.setAdditionalGearStorage(newAdditionalGearStorage);
 
 		// verification
-		// reload user info to ensure the storage info isnt cached
+		// reload user info to ensure the storage info isn't cached
 		assertThat(cartridge.getAdditionalGearStorage()).isEqualTo(newAdditionalGearStorage);
 	}
 
@@ -121,7 +121,7 @@ public class StandaloneCartridgeResourceIntegrationTest extends TestTimer {
 		cartridge.setAdditionalGearStorage(additionalGearStorage);
 
 		// verification
-		// reload user info to ensure the storage info isnt cached
+		// reload user info to ensure the storage info isn't cached
 		IUser newUser = new TestConnectionBuilder()
 				.defaultCredentials()
 				.disableSSLCertificateChecks()

--- a/src/test/java/com/openshift/internal/client/StandaloneCartridgeResourceTest.java
+++ b/src/test/java/com/openshift/internal/client/StandaloneCartridgeResourceTest.java
@@ -27,7 +27,6 @@ import java.net.URISyntaxException;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import com.openshift.client.IApplication;
 import com.openshift.client.IDomain;
@@ -154,7 +153,7 @@ public class StandaloneCartridgeResourceTest {
 		int additionalGearStorage = cartridge.getAdditionalGearStorage();
 
 		// verification
-		// reload user info to ensure the storage info isnt cached
+		// reload user info to ensure the storage info isn't cached
 		assertThat(additionalGearStorage).isNotEqualTo(IGearGroup.NO_ADDITIONAL_GEAR_STORAGE);
 	}
 
@@ -169,7 +168,7 @@ public class StandaloneCartridgeResourceTest {
 		cartridge.setAdditionalGearStorage(newAdditionalGearStorage);
 
 		// verification
-		// reload user info to ensure the storage info isnt cached
+		// reload user info to ensure the storage info isn't cached
 		mockDirector.mockGetGearGroups("foobarz", "springeap6", Samples.GET_DOMAINS_FOOBARZ_APPLICATIONS_SPRINGEAP6_GEARGROUPS_12ADDITIONALGEARSTORAGE);
 		assertThat(cartridge.getAdditionalGearStorage()).isEqualTo(newAdditionalGearStorage);
 	}

--- a/src/test/java/com/openshift/internal/client/StandaloneCartridgeTest.java
+++ b/src/test/java/com/openshift/internal/client/StandaloneCartridgeTest.java
@@ -47,7 +47,7 @@ public class StandaloneCartridgeTest extends TestTimer {
 
 	@Test
 	public void shouldDownloadableWithDifferentNameEqualsDownloadable() throws MalformedURLException {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertThat(new StandaloneCartridge("redhat", new URL(CartridgeTestUtils.GO_URL)))
@@ -60,7 +60,7 @@ public class StandaloneCartridgeTest extends TestTimer {
 
 	@Test
 	public void shouldDownloadableStandaloneNotEqualsDownloadableEmbeddable() throws MalformedURLException {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertThat(new StandaloneCartridge(new URL(CartridgeTestUtils.GO_URL)))
@@ -74,7 +74,7 @@ public class StandaloneCartridgeTest extends TestTimer {
 		CartridgeAssert<IStandaloneCartridge> cartridgeAssert = new CartridgeAssert<IStandaloneCartridge>(nodeJs);
 
 		// operation
-		// verifcation
+		// verification
 		cartridgeAssert
 				.hasName("nodejs-0.6")
 				.hasDisplayName("Node.js 0.6")
@@ -86,7 +86,7 @@ public class StandaloneCartridgeTest extends TestTimer {
 	
 	@Test
 	public void standaloneCartridgeResourceShouldEqualStandAloneCartridgeWithoutName() throws MalformedURLException {
-		// pre-coniditions
+		// pre-conditions
 		// operation
 		// verification
 		assertEquals(new StandaloneCartridge(new URL(CartridgeTestUtils.FOREMAN_URL)),

--- a/src/test/java/com/openshift/internal/client/TestTimer.java
+++ b/src/test/java/com/openshift/internal/client/TestTimer.java
@@ -1,7 +1,7 @@
 package com.openshift.internal.client;
 
 import com.openshift.client.OpenShiftException;
-import com.openshift.client.utils.TestConnectionFactory;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;

--- a/src/test/java/com/openshift/internal/client/UserResourceIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/client/UserResourceIntegrationTest.java
@@ -58,7 +58,7 @@ public class UserResourceIntegrationTest extends TestTimer {
 	
 	@Test(expected = InvalidCredentialsOpenShiftException.class)
 	public void shouldThrowIfInvalidCredentials() throws Exception {
-		// dont test on dev server
+		// don't test on dev server
 		OpenShiftTestConfiguration configuration = new OpenShiftTestConfiguration();
 		if (configuration.isDevelopmentServer()) {
 			throw new InvalidCredentialsOpenShiftException(null, new HttpClientException(""), null);

--- a/src/test/java/com/openshift/internal/client/httpclient/HttpClientTest.java
+++ b/src/test/java/com/openshift/internal/client/httpclient/HttpClientTest.java
@@ -728,7 +728,7 @@ public class HttpClientTest extends TestTimer {
 			return super.createConnection(new URL("http://localhost"), username, password, authKey, authIV,
 					token, userAgent, acceptedVersion, acceptedMediaType, sslAuthorizationCallback, NO_TIMEOUT);
 		}
-	};
+	}
 
 	private void restoreSystemProperty(String property, String value) {
 		if (value == null) {

--- a/src/test/java/com/openshift/internal/client/httpclient/request/FormUrlEncodedMediaTypeTest.java
+++ b/src/test/java/com/openshift/internal/client/httpclient/request/FormUrlEncodedMediaTypeTest.java
@@ -67,7 +67,7 @@ public class FormUrlEncodedMediaTypeTest {
 					.add(new StringParameter("name", "adietish"))
 				, out);
 		// verification
-		assertThat(out.toString().startsWith("&")).isFalse();;
+		assertThat(out.toString().startsWith("&")).isFalse();
 	}
 
 	@Test

--- a/src/test/java/com/openshift/internal/client/response/QuickstartDTOCartridgeQueryTest.java
+++ b/src/test/java/com/openshift/internal/client/response/QuickstartDTOCartridgeQueryTest.java
@@ -141,7 +141,7 @@ public class QuickstartDTOCartridgeQueryTest {
 
 		// verification
 		assertThat(cartridge).isNotNull();
-		assertThat(cartridge.isDownloadable()).isFalse();;
+		assertThat(cartridge.isDownloadable()).isFalse();
 		assertThat(cartridges).hasSize(1);
 	}
 


### PR DESCRIPTION
Removed unnecessary semicolons.
Removed unused imports.
Simplified method call.
Fixed some typos.
Fixed some method names to use camelCase.
Fixed some javadoc parameters definitions.