### PR TITLE
Exception handling

### DIFF
--- a/src/main/java/com/openshift3/client/ResourceKind.java
+++ b/src/main/java/com/openshift3/client/ResourceKind.java
@@ -22,6 +22,7 @@ public enum ResourceKind {
 	Project("projects"),
 	Pod("pods"),
 	ReplicationController("replicationControllers"),
+	Route("routes"),
 	Status(""),
 	Service("services");
 

--- a/src/main/java/com/openshift3/client/model/IRoute.java
+++ b/src/main/java/com/openshift3/client/model/IRoute.java
@@ -1,5 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * All rights reserved. This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors: Red Hat, Inc.
+ ******************************************************************************/
 package com.openshift3.client.model;
 
+/**
+ * OpenShift route to Service
+ */
 public interface IRoute extends IResource {
+
+	/**
+	 * Retrieves the externally available hostname that can be used to access
+	 * service.
+	 * 
+	 * @return Route hostname.
+	 */
+	String getHost();
+
+	/**
+	 * Sets the externally available hostname that can be used to access
+	 * service.
+	 * 
+	 * @param host
+	 *            hostname to use
+	 */
+	void setHost(String host);
+
+	/**
+	 * Retrieves the name of the service this route leads to.
+	 * 
+	 * @return Name of the service for this route.
+	 */
+	String getServiceName();
+
+	/**
+	 * Sets the name of the service this route should lead to.
+	 * 
+	 * @param serviceName
+	 *            Name of the service this route should lead to.
+	 */
+	void setServiceName(String serviceName);
 
 }

--- a/src/main/java/com/openshift3/client/model/IRoute.java
+++ b/src/main/java/com/openshift3/client/model/IRoute.java
@@ -1,0 +1,5 @@
+package com.openshift3.client.model;
+
+public interface IRoute extends IResource {
+
+}

--- a/src/main/java/com/openshift3/internal/client/DefaultClient.java
+++ b/src/main/java/com/openshift3/internal/client/DefaultClient.java
@@ -264,6 +264,7 @@ public class DefaultClient implements IClient{
 			typeMappings.put(ResourceKind.DeploymentConfig, osEndpoint);
 			typeMappings.put(ResourceKind.ImageRepository, osEndpoint);
 			typeMappings.put(ResourceKind.Project, osEndpoint);
+			typeMappings.put(ResourceKind.Route, osEndpoint);
 			
 			//Kubernetes endpoints
 			final String k8eEndpoint = String.format("%s/%s", apiEndpoint, getKubernetesVersion());

--- a/src/main/java/com/openshift3/internal/client/ResourceFactory.java
+++ b/src/main/java/com/openshift3/internal/client/ResourceFactory.java
@@ -27,6 +27,7 @@ import com.openshift3.internal.client.model.ImageRepository;
 import com.openshift3.internal.client.model.Pod;
 import com.openshift3.internal.client.model.Project;
 import com.openshift3.internal.client.model.ReplicationController;
+import com.openshift3.internal.client.model.Route;
 import com.openshift3.internal.client.model.Service;
 import com.openshift3.internal.client.model.Status;
 import com.openshift3.internal.client.model.properties.ResourcePropertiesRegistry;
@@ -47,6 +48,7 @@ public class ResourceFactory implements IResourceFactory{
 		IMPL_MAP.put(ResourceKind.Project, Project.class);
 		IMPL_MAP.put(ResourceKind.Pod, Pod.class);
 		IMPL_MAP.put(ResourceKind.ReplicationController, ReplicationController.class);
+		IMPL_MAP.put(ResourceKind.Route, Route.class);
 		IMPL_MAP.put(ResourceKind.Status, Status.class);
 		IMPL_MAP.put(ResourceKind.Service, Service.class);
 	}

--- a/src/main/java/com/openshift3/internal/client/model/Route.java
+++ b/src/main/java/com/openshift3/internal/client/model/Route.java
@@ -1,3 +1,11 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * All rights reserved. This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors: Red Hat, Inc.
+ ******************************************************************************/
 package com.openshift3.internal.client.model;
 
 import java.util.Map;
@@ -8,8 +16,28 @@ import com.openshift3.client.IClient;
 import com.openshift3.client.model.IRoute;
 
 public class Route extends KubernetesResource implements IRoute {
-    public Route(ModelNode node, IClient client, Map<String, String[]> propertyKeys) {
-        super(node, client, propertyKeys);
-    }
+	public Route(ModelNode node, IClient client, Map<String, String[]> propertyKeys) {
+		super(node, client, propertyKeys);
+	}
+
+	@Override
+	public String getHost() {
+		return asString(ROUTE_HOST);
+	}
+
+	@Override
+	public void setHost(String host) {
+		get(ROUTE_HOST).set(host);
+	}
+
+	@Override
+	public String getServiceName() {
+		return asString(ROUTE_SERVICE_NAME);
+	}
+
+	@Override
+	public void setServiceName(String serviceName) {
+		get(ROUTE_SERVICE_NAME).set(serviceName);
+	}
 
 }

--- a/src/main/java/com/openshift3/internal/client/model/Route.java
+++ b/src/main/java/com/openshift3/internal/client/model/Route.java
@@ -1,0 +1,15 @@
+package com.openshift3.internal.client.model;
+
+import java.util.Map;
+
+import org.jboss.dmr.ModelNode;
+
+import com.openshift3.client.IClient;
+import com.openshift3.client.model.IRoute;
+
+public class Route extends KubernetesResource implements IRoute {
+    public Route(ModelNode node, IClient client, Map<String, String[]> propertyKeys) {
+        super(node, client, propertyKeys);
+    }
+
+}

--- a/src/main/java/com/openshift3/internal/client/model/properties/ResourcePropertiesRegistry.java
+++ b/src/main/java/com/openshift3/internal/client/model/properties/ResourcePropertiesRegistry.java
@@ -87,6 +87,9 @@ public final class ResourcePropertiesRegistry implements ResourcePropertyKeys {
 		put(IMAGEREPO_DOCKER_IMAGE_REPO, new String[]{"status","dockerImageRepository"});
 		
 		put(PROJECT_DISPLAY_NAME, new String[]{"displayName"});
+		
+		put(ROUTE_HOST, new String[] { "host" });
+		put(ROUTE_SERVICE_NAME, new String[] { "serviceName" });
 	}};
 
 	private ResourcePropertiesRegistry(){

--- a/src/main/java/com/openshift3/internal/client/model/properties/ResourcePropertiesRegistry.java
+++ b/src/main/java/com/openshift3/internal/client/model/properties/ResourcePropertiesRegistry.java
@@ -100,6 +100,7 @@ public final class ResourcePropertiesRegistry implements ResourcePropertyKeys {
 		versionPropertyMap.put(new VersionKey(OpenShiftAPIVersion.v1beta1, ResourceKind.DeploymentConfig), V1BETA1_OPENSHIFT_MAP);
 		versionPropertyMap.put(new VersionKey(OpenShiftAPIVersion.v1beta1, ResourceKind.ImageRepository), V1BETA1_OPENSHIFT_MAP);
 		versionPropertyMap.put(new VersionKey(OpenShiftAPIVersion.v1beta1, ResourceKind.Project), V1BETA1_OPENSHIFT_MAP);
+		versionPropertyMap.put(new VersionKey(OpenShiftAPIVersion.v1beta1, ResourceKind.Route), V1BETA1_OPENSHIFT_MAP);
 	}
 	
 	public static final ResourcePropertiesRegistry getInstance(){

--- a/src/main/java/com/openshift3/internal/client/model/properties/ResourcePropertyKeys.java
+++ b/src/main/java/com/openshift3/internal/client/model/properties/ResourcePropertyKeys.java
@@ -41,6 +41,8 @@ public interface ResourcePropertyKeys extends BuildConfigPropertyKeys{
 	static final String DEPLOYMENTCONFIG_TRIGGERS = "deploymentconfig.triggers";
 	static final String IMAGEREPO_DOCKER_IMAGE_REPO = "imagerepo.dockerimagerepo";
 	static final String PROJECT_DISPLAY_NAME = "project.displayname";
+	static final String ROUTE_HOST = "route.host";
+	static final String ROUTE_SERVICE_NAME = "route.serviceName";
 	
 	static final String POD_CONTAINERS = "pod.containers";
 	static final String POD_HOST = "pod.host";


### PR DESCRIPTION
Trying to parse non-JSON results (e.g. "Forbidden by default...") throws new exception and the original one is lost. This is a simple fix and will fail if returned JSON is not a status.