### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/src/main/java/com/openshift/client/ApplicationScale.java
+++ b/src/main/java/com/openshift/client/ApplicationScale.java
@@ -24,16 +24,16 @@ public enum ApplicationScale {
 
 	private final String value;
 	
+	private ApplicationScale(final String value) {
+		this.value = value;
+	}
+	
 	public static ApplicationScale safeValueOf(final String value) {
 		if(value == null 
 				|| !SCALING_TRUE.equals(value.toUpperCase())) {
 			return NO_SCALE;
 		}
 		return SCALE;
-	}
-	
-	private ApplicationScale(final String value) {
-		this.value = value;
 	}
 	
 	public String getValue() {

--- a/src/main/java/com/openshift/client/cartridge/EmbeddableCartridge.java
+++ b/src/main/java/com/openshift/client/cartridge/EmbeddableCartridge.java
@@ -38,12 +38,7 @@ public class EmbeddableCartridge extends BaseCartridge implements IEmbeddableCar
 	public EmbeddableCartridge(final String name, final URL url) {
 		super(name, url);
 	}
-
-	@Override
-	public CartridgeType getType() {
-		return CartridgeType.EMBEDDED;
-	}
-
+	
 	/**
 	 * Constructor used when available cartridges are loaded from OpenShift
 	 * 
@@ -51,6 +46,11 @@ public class EmbeddableCartridge extends BaseCartridge implements IEmbeddableCar
 	 */
 	public EmbeddableCartridge(final String name, String displayName, String description, boolean obsolete) {
 		super(name, displayName, description, obsolete);
+	}
+
+	@Override
+	public CartridgeType getType() {
+		return CartridgeType.EMBEDDED;
 	}
 
 	@Override

--- a/src/test/java/com/openshift/client/fakes/WaitingHttpServerFake.java
+++ b/src/test/java/com/openshift/client/fakes/WaitingHttpServerFake.java
@@ -20,6 +20,10 @@ import java.io.OutputStream;
 public class WaitingHttpServerFake extends HttpServerFake {
 
     private long delay;
+    
+    public WaitingHttpServerFake(long delay){
+        this.delay = delay;
+    }
 
     @Override
     protected void write(byte[] text, OutputStream outputStream) throws IOException {
@@ -32,7 +36,4 @@ public class WaitingHttpServerFake extends HttpServerFake {
         }
     }
 
-    public WaitingHttpServerFake(long delay){
-        this.delay = delay;
-    }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed