### PR TITLE
Code quality fix - Exceptions should not be thrown in finally blocks. 

### DIFF
--- a/src/test/java/com/openshift/client/fakes/UserConfigurationFake.java
+++ b/src/test/java/com/openshift/client/fakes/UserConfigurationFake.java
@@ -53,7 +53,7 @@ public class UserConfigurationFake extends UserConfiguration {
 			try {
 				StreamUtils.close(writer);
 			} catch (Exception e) {
-				throw new RuntimeException(e);
+				// ignore
 			}
 		}		
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1163 - Exceptions should not be thrown in finally blocks. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1163

Please let me know if you have any questions.

Faisal Hameed