### PR TITLE
Code quality fix - Math operands should be cast before assignment.

### DIFF
--- a/src/main/java/com/openshift/internal/client/ApplicationResource.java
+++ b/src/main/java/com/openshift/internal/client/ApplicationResource.java
@@ -76,7 +76,7 @@ import com.openshift.internal.client.utils.StringUtils;
  */
 public class ApplicationResource extends AbstractOpenShiftResource implements IApplication {
 
-	private static final long APPLICATION_WAIT_RETRY_DELAY = 2 * 1024;
+	private static final long APPLICATION_WAIT_RETRY_DELAY = 2 * 1024L;
 	private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationResource.class);
 
 	private static final String LINK_DELETE_APPLICATION = "DELETE";

--- a/src/test/java/com/openshift/client/utils/ApplicationAssert.java
+++ b/src/test/java/com/openshift/client/utils/ApplicationAssert.java
@@ -48,7 +48,7 @@ public class ApplicationAssert implements AssertExtension {
 	public static final Pattern APPLICATION_URL_PATTERN = Pattern.compile("https*://(.+)-([^\\.]+)\\.(.+)/(.*)");
 	public static final Pattern GIT_URL_PATTERN = Pattern.compile("ssh://(.+)@(.+)-([^\\.]+)\\.(.+)/~/git/(.+).git/");
 	
-	private static final long APPLICATION_WAIT_TIMEOUT = 2 * 60 * 1000;
+	private static final long APPLICATION_WAIT_TIMEOUT = 2 * 60 * 1000L;
 	
 	private IApplication application;
 

--- a/src/test/java/com/openshift/client/utils/ApplicationTestUtils.java
+++ b/src/test/java/com/openshift/client/utils/ApplicationTestUtils.java
@@ -32,7 +32,7 @@ import com.openshift.client.cartridge.query.LatestVersionOf;
 public class ApplicationTestUtils {
 
 	// 3 minutes
-	private static final long WAIT_FOR_APPLICATION = 3 * 60 * 1000;
+	private static final long WAIT_FOR_APPLICATION = 3 * 60 * 1000L;
 
 	public static String createRandomApplicationName() {
 		return "app" + String.valueOf(System.currentTimeMillis());

--- a/src/test/java/com/openshift/internal/client/ApplicationResourceIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/client/ApplicationResourceIntegrationTest.java
@@ -47,7 +47,7 @@ import com.openshift.client.utils.TestConnectionBuilder;
  */
 public class ApplicationResourceIntegrationTest extends TestTimer {
 
-	private static final long WAIT_TIMEOUT = 3 * 60 * 1000;
+	private static final long WAIT_TIMEOUT = 3 * 60 * 1000L;
 
 	private IUser user;
 	private IDomain domain;

--- a/src/test/java/com/openshift/internal/client/ApplicationResourceTest.java
+++ b/src/test/java/com/openshift/internal/client/ApplicationResourceTest.java
@@ -511,7 +511,7 @@ public class ApplicationResourceTest extends TestTimer {
 		assertThat(app).isNotNull().isInstanceOf(ApplicationResource.class);
 		ApplicationResource spy = Mockito.spy(((ApplicationResource) app));
 		Mockito.doReturn(false).when(spy).canResolv(Mockito.anyString());
-		long timeout = 2 * 1000;
+		long timeout = 2 * 1000L;
 		long startTime = System.currentTimeMillis();
 
 		// operation
@@ -526,7 +526,7 @@ public class ApplicationResourceTest extends TestTimer {
 	public void shouldEndBeforeTimeout() throws HttpClientException, Throwable {
 		// pre-conditions
 		long startTime = System.currentTimeMillis();
-		long timeout = 10 * 1000;
+		long timeout = 10 * 1000L;
 		final IApplication app = domain.getApplicationByName("springeap6");
 		assertThat(app).isNotNull().isInstanceOf(ApplicationResource.class);
 		ApplicationResource spy = Mockito.spy(((ApplicationResource) app));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2184 - Math operands should be cast before assignment.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2184
Please let me know if you have any questions.

Faisal Hameed