### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/com/openshift/client/cartridge/query/LatestVersionOf.java
+++ b/src/main/java/com/openshift/client/cartridge/query/LatestVersionOf.java
@@ -20,6 +20,8 @@ import com.openshift.client.cartridge.IStandaloneCartridge;
  */
 public class LatestVersionOf {
 
+	private LatestVersionOf() {}
+
 	public static  LatestEmbeddableCartridge mmsAgent() {
 		return new LatestEmbeddableCartridge(IEmbeddableCartridge.NAME_10GEN_MMS_AGENT);
 	}

--- a/src/main/java/com/openshift/client/utils/HostUtils.java
+++ b/src/main/java/com/openshift/client/utils/HostUtils.java
@@ -20,6 +20,8 @@ import java.net.UnknownHostException;
  */
 public class HostUtils {
 
+	private HostUtils() {}
+
 	public static boolean canResolv(String urlString) throws MalformedURLException {
 		try {
 			URL url = new URL(urlString);

--- a/src/main/java/com/openshift/client/utils/OpenShiftResourceUtils.java
+++ b/src/main/java/com/openshift/client/utils/OpenShiftResourceUtils.java
@@ -20,6 +20,8 @@ import com.openshift.client.cartridge.ICartridge;
  */
 public class OpenShiftResourceUtils {
 
+	private OpenShiftResourceUtils() {}
+
 	public static List<String> toNames(ICartridge... cartridges) {
 		List<String> cartridgeNames = new ArrayList<String>();
 		if (cartridges == null) {

--- a/src/main/java/com/openshift/client/utils/RFC822DateUtils.java
+++ b/src/main/java/com/openshift/client/utils/RFC822DateUtils.java
@@ -21,6 +21,8 @@ import javax.xml.datatype.DatatypeFactory;
  */
 public class RFC822DateUtils {
 
+	private RFC822DateUtils() {}
+
 	/**
 	 * Returns a date instance for a given timestamp string that complies to the
 	 * RFC 822 standard

--- a/src/main/java/com/openshift/internal/client/utils/Assert.java
+++ b/src/main/java/com/openshift/internal/client/utils/Assert.java
@@ -16,6 +16,8 @@ package com.openshift.internal.client.utils;
  * @author André Dietisheim
  */
 public class Assert {
+    
+    private Assert() {}
 
 	public static final class AssertionFailedException extends RuntimeException {
 

--- a/src/main/java/com/openshift/internal/client/utils/IOpenShiftJsonConstants.java
+++ b/src/main/java/com/openshift/internal/client/utils/IOpenShiftJsonConstants.java
@@ -16,6 +16,8 @@ package com.openshift.internal.client.utils;
  */
 public class IOpenShiftJsonConstants {
 
+	private IOpenShiftJsonConstants() {}
+
 	public static final String PROPERTY_ACTION = "action";
 	public static final String PROPERTY_ADDITIONAL_GEAR_STORAGE = "additional_gear_storage";
 	public static final String PROPERTY_ALIAS = "alias";

--- a/src/main/java/com/openshift/internal/client/utils/IOpenShiftParameterConstants.java
+++ b/src/main/java/com/openshift/internal/client/utils/IOpenShiftParameterConstants.java
@@ -14,6 +14,8 @@ package com.openshift.internal.client.utils;
  * @author André Dietisheim
  */
 public class IOpenShiftParameterConstants {
+    
+    private IOpenShiftParameterConstants() {}
 
 	public static final String PARAMETER_ID = "id";
 	public static final String PARAMETER_INCLUDE = "include";

--- a/src/main/java/com/openshift/internal/client/utils/StreamUtils.java
+++ b/src/main/java/com/openshift/internal/client/utils/StreamUtils.java
@@ -24,6 +24,8 @@ import java.io.Writer;
  */
 public class StreamUtils {
 
+	private StreamUtils() {}
+
 	public static final String UTF_8 = "UTF-8";
 
 	private static final byte[] buffer = new byte[1024];

--- a/src/main/java/com/openshift/internal/client/utils/StringUtils.java
+++ b/src/main/java/com/openshift/internal/client/utils/StringUtils.java
@@ -16,6 +16,8 @@ package com.openshift.internal.client.utils;
  */
 public class StringUtils {
 
+	private StringUtils() {}
+
 	public static String toLowerCase(String message) {
 		if (message == null) {
 			return null;

--- a/src/test/java/com/openshift/client/fakes/TestSSHKey.java
+++ b/src/test/java/com/openshift/client/fakes/TestSSHKey.java
@@ -49,6 +49,8 @@ public class TestSSHKey {
 					"wktsrE+f2VdVt0McRLVAO6rdJRyMUX0rTbm7SABRVSX+zeQjlfqbbUtYFc7TIfd4RQc3GaISG" +
 					"1rS3C4svRSjdWaG36vDY2KxowdFvpKj8i8IYNPlLoRA/7EzzyneS6iyw" +
 					"== created by com.openshift.client";
+	
+	private TestSSHKey() {}
 
 	public static SSHKeyPair create() throws IOException, OpenShiftException {
 		File privateKeyFile = File.createTempFile(createRandomString(), null);

--- a/src/test/java/com/openshift/client/portforwarding/PortForwardingL.java
+++ b/src/test/java/com/openshift/client/portforwarding/PortForwardingL.java
@@ -16,6 +16,9 @@ import java.awt.*;
 import javax.swing.*;
 
 public class PortForwardingL{
+
+  private PortForwardingL() {}
+    
   public static void main(String[] arg){
 
     int lport;

--- a/src/test/java/com/openshift/client/utils/ApplicationTestUtils.java
+++ b/src/test/java/com/openshift/client/utils/ApplicationTestUtils.java
@@ -31,6 +31,8 @@ import com.openshift.client.cartridge.query.LatestVersionOf;
  */
 public class ApplicationTestUtils {
 
+	private ApplicationTestUtils() {}
+
 	// 3 minutes
 	private static final long WAIT_FOR_APPLICATION = 3 * 60 * 1000;
 

--- a/src/test/java/com/openshift/client/utils/CartridgeAsserts.java
+++ b/src/test/java/com/openshift/client/utils/CartridgeAsserts.java
@@ -22,6 +22,8 @@ import com.openshift.client.cartridge.ICartridge;
  */
 public class CartridgeAsserts {
 
+	private CartridgeAsserts() {}
+
 	public static void assertThatContainsCartridge(String cartridgeName, Collection<ICartridge> cartridges) {
 		boolean found = false;
 		for (ICartridge cartridge : cartridges) {

--- a/src/test/java/com/openshift/client/utils/CartridgeTestUtils.java
+++ b/src/test/java/com/openshift/client/utils/CartridgeTestUtils.java
@@ -58,6 +58,8 @@ public class CartridgeTestUtils {
 	public static final String SWITCHYARD_06_NAME = "switchyard-0.6";
 	public static final String POSTGRESQL_84_NAME = "postgresql-8.4";
 	public static final String HAPROXY_14_NAME = "haproxy-1.4";
+	
+	private CartridgeTestUtils() {}
 
 
 	public static IStandaloneCartridge aerogear() throws MalformedURLException {

--- a/src/test/java/com/openshift/client/utils/DomainTestUtils.java
+++ b/src/test/java/com/openshift/client/utils/DomainTestUtils.java
@@ -21,6 +21,8 @@ import com.openshift.client.OpenShiftException;
  */
 public class DomainTestUtils {
 
+	private DomainTestUtils() {}
+
 	public static void destroyAllDomains(IUser user) {
 		if (user == null) {
 			return;

--- a/src/test/java/com/openshift/client/utils/EmbeddedCartridgeTestUtils.java
+++ b/src/test/java/com/openshift/client/utils/EmbeddedCartridgeTestUtils.java
@@ -22,6 +22,8 @@ import com.openshift.client.cartridge.query.LatestVersionOf;
  */
 public class EmbeddedCartridgeTestUtils {
 
+	private EmbeddedCartridgeTestUtils() {}
+
 	public static void silentlyDestroy(LatestEmbeddableCartridge selector, IApplication application) {
 		try {
 			if (selector == null

--- a/src/test/java/com/openshift/client/utils/FileUtils.java
+++ b/src/test/java/com/openshift/client/utils/FileUtils.java
@@ -21,6 +21,8 @@ import java.io.StringReader;
 public class FileUtils {
 
 	private static final String JAVA_IO_TEMP = "java.io.tmpdir";
+	
+	private FileUtils() {}
 
 	public static void writeTo(String data, String path) throws IOException {
 		writeTo(data, new File(path));

--- a/src/test/java/com/openshift/client/utils/GearProfileTestUtils.java
+++ b/src/test/java/com/openshift/client/utils/GearProfileTestUtils.java
@@ -9,6 +9,9 @@ import java.util.List;
  * Created by corey on 2/17/14.
  */
 public class GearProfileTestUtils {
+
+	private GearProfileTestUtils() {}
+
 	public static IGearProfile getFirstAvailableGearProfile(IDomain domain) {
 		IGearProfile gear = null;
 		List<IGearProfile> gears = domain.getAvailableGearProfiles();

--- a/src/test/java/com/openshift/client/utils/QuickstartTestUtils.java
+++ b/src/test/java/com/openshift/client/utils/QuickstartTestUtils.java
@@ -43,6 +43,8 @@ public class QuickstartTestUtils {
 	public static final String TEXTPRESS = "TextPress";
 	public static final String WILDFLY_8 = "WildFly 8";
 	public static final String WORDPRESS_3X = "WordPress 3.x";
+	
+	private QuickstartTestUtils() {}
 
 	public static String createQuickstartsJsonForCartridgeSpec(String... cartridgesSpecs) {
 		List<ModelNode> quickstartNodes = new ArrayList<ModelNode>();

--- a/src/test/java/com/openshift/client/utils/SSHKeyTestUtils.java
+++ b/src/test/java/com/openshift/client/utils/SSHKeyTestUtils.java
@@ -40,6 +40,8 @@ public class SSHKeyTestUtils {
 
 	public static final String SSH_RSA = "ssh-rsa";
 	public static final String SSH_DSA = "ssh-dss";
+	
+	private SSHKeyTestUtils() {}
 
 	/**
 	 * Returns the key with the given name out of the keys in the given list of

--- a/src/test/java/com/openshift/client/utils/StringUtils.java
+++ b/src/test/java/com/openshift/client/utils/StringUtils.java
@@ -15,6 +15,8 @@ package com.openshift.client.utils;
  */
 public class StringUtils {
 
+	private StringUtils() {}
+
 	public static String createRandomString() {
 		return String.valueOf(System.currentTimeMillis());
 	}

--- a/src/test/java/com/openshift/internal/client/LinkRetriever.java
+++ b/src/test/java/com/openshift/internal/client/LinkRetriever.java
@@ -27,6 +27,8 @@ import com.openshift.internal.client.response.Link;
 
 public class LinkRetriever {
 
+	private LinkRetriever() {}
+
 	/**
 	 * Retrieves the link identified by the given name from the given resource.
 	 * @throws OpenShiftException 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed