### PR TITLE
Code quality fix - Collection.isEmpty() should be used to test for emptiness. 

### DIFF
--- a/src/main/java/com/openshift/client/Messages.java
+++ b/src/main/java/com/openshift/client/Messages.java
@@ -57,8 +57,8 @@ public class Messages {
 	 */
 	public Message getFirstBy(IField field, ISeverity severity) {
 		List<Message> messages = getBy(field, severity);
-		if (messages == null
-				|| messages.size() == 0) {
+		if (messages == null 
+						|| messages.isEmpty()) {
 			return null;
 		}
 		
@@ -79,8 +79,8 @@ public class Messages {
 	 */
 	public List<Message> getBy(IField field, ISeverity severity) {
 		List<Message> messages = getBy(field);
-		if (messages == null
-				|| messages.size() == 0) {
+		if (messages == null 
+						|| messages.isEmpty()) {
 			return null;
 		}
 		List<Message> matchingMessages = new ArrayList<Message>();
@@ -106,7 +106,7 @@ public class Messages {
 	public Message getFirstBy(IField field) {
 		List<Message> messages = getBy(field);
 		if (messages == null 
-				|| messages.size() == 0) {
+						|| messages.isEmpty()) {
 			return null;
 		}
 		return messages.get(0);
@@ -131,7 +131,7 @@ public class Messages {
 	
 	public boolean hasMessages() {
 		for (List<Message> messages : messagesByField.values()) {
-			if (messages.size() > 0) {
+			if (!messages.isEmpty()) {
 				return true;
 			}
 		}

--- a/src/main/java/com/openshift/client/cartridge/query/AbstractCartridgeQuery.java
+++ b/src/main/java/com/openshift/client/cartridge/query/AbstractCartridgeQuery.java
@@ -47,7 +47,7 @@ public abstract class AbstractCartridgeQuery implements ICartridgeQuery {
 	public <C extends ICartridge> C get(List<C> cartridges) {
 		List<C> matchingCartridges = getAll(cartridges);
 		 if (matchingCartridges == null
-				 || matchingCartridges.size() == 0) {
+				 || matchingCartridges.isEmpty()) {
 			 return null;
 		 }
 		 return matchingCartridges.iterator().next();

--- a/src/main/java/com/openshift/internal/client/APIResource.java
+++ b/src/main/java/com/openshift/internal/client/APIResource.java
@@ -202,7 +202,7 @@ public class APIResource extends AbstractOpenShiftResource implements IOpenShift
 
 	public IDomain getDefaultDomain() {
 		final List<IDomain> domains = getDomains();
-		if (domains.size() > 0) {
+		if (!domains.isEmpty()) {
 			return domains.get(0);
 		}
 		return null;

--- a/src/main/java/com/openshift/internal/client/AbstractOpenShiftResource.java
+++ b/src/main/java/com/openshift/internal/client/AbstractOpenShiftResource.java
@@ -217,7 +217,7 @@ public abstract class AbstractOpenShiftResource implements IOpenShiftResource {
 		protected Parameters addCartridges(Collection<ICartridge> cartridges) {
 			ParameterValueArray parameters = new ParameterValueArray();
 			if (cartridges != null
-					&& cartridges.size() > 0) {
+					&& !cartridges.isEmpty()) {
 				parameters.addAll(createCartridgeParameters(cartridges));
 			}
 
@@ -268,8 +268,8 @@ public abstract class AbstractOpenShiftResource implements IOpenShiftResource {
 
 		private List<ParameterValueMap> createCartridgeParameters(Collection<ICartridge> cartridges) {
 			List<ParameterValueMap> parameters = new ArrayList<ParameterValueMap>();
-			if (cartridges == null
-					|| cartridges.size() == 0) {
+			if (cartridges == null 
+							|| cartridges.isEmpty()) {
 				return parameters;
 			}
 			

--- a/src/main/java/com/openshift/internal/client/DomainResource.java
+++ b/src/main/java/com/openshift/internal/client/DomainResource.java
@@ -239,7 +239,7 @@ public class DomainResource extends AbstractOpenShiftResource implements IDomain
 
 	@Override
 	public boolean hasApplicationByCartridge(IStandaloneCartridge cartridge) throws OpenShiftException {
-		return getApplicationsByCartridge(cartridge).size() > 0;
+		return !getApplicationsByCartridge(cartridge).isEmpty();
 	}
 
 	@Override
@@ -464,8 +464,8 @@ public class DomainResource extends AbstractOpenShiftResource implements IDomain
 				final IGearProfile gearProfile, final String initialGitUrl, final int timeout,
 				String region, Map<String, String> environmentVariables, Collection<ICartridge> cartridges)
 				throws OpenShiftException {
-			if (cartridges == null
-					|| cartridges.size() == 0) {
+			if (cartridges == null 
+								|| cartridges.isEmpty()) {
 				throw new OpenShiftException("Cartridges are mandatory but none were provided.");
 			}
 

--- a/src/main/java/com/openshift/internal/client/response/Link.java
+++ b/src/main/java/com/openshift/internal/client/response/Link.java
@@ -247,7 +247,7 @@ public class Link {
 
 	private String addParameters(String url, List<Parameter> urlParameters) {
 		if (urlParameters == null
-				|| urlParameters.size() == 0) {
+				|| urlParameters.isEmpty()) {
 			return url;
 		}
 		try {
@@ -278,7 +278,7 @@ public class Link {
 	 */
 	private String substituteUrlPathParameters(String href, List<Parameter> urlPathParameters) {
 		if (urlPathParameters == null
-				|| urlPathParameters.size() == 0) {
+				|| urlPathParameters.isEmpty()) {
 			return href;
 		}
 		return substituteVariables(href, urlPathParameters);

--- a/src/test/java/com/openshift/internal/client/DomainResourceTest.java
+++ b/src/test/java/com/openshift/internal/client/DomainResourceTest.java
@@ -195,7 +195,7 @@ public class DomainResourceTest extends TestTimer {
 		// operation
 		List<IGearProfile> availableGearSizes = domain.getAvailableGearProfiles();
 		// verifications
-		assertThat(availableGearSizes.size() > 0);
+		assertThat(!availableGearSizes.isEmpty());
 	}
 
 	@Test

--- a/src/test/java/com/openshift/internal/client/response/QuickstartDTOCartridgeQueryTest.java
+++ b/src/test/java/com/openshift/internal/client/response/QuickstartDTOCartridgeQueryTest.java
@@ -296,7 +296,7 @@ public class QuickstartDTOCartridgeQueryTest {
 
 	private ICartridgeQuery getFirstCartridgeQuery(String cartridgesJson) {
 		List<ICartridgeQuery> queries = QuickstartTestUtils.getCartridgeQueriesForSingleQuickstart(cartridgesJson);
-		assertThat(queries.size() > 0);
+		assertThat(!queries.isEmpty());
 		return queries.get(0);
 	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - Collection.isEmpty() should be used to test for emptiness. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.

Faisal Hameed