### PR TITLE
Multiple code quality fix-2

### DIFF
--- a/src/test/java/com/openshift/client/fakes/HttpsServerFake.java
+++ b/src/test/java/com/openshift/client/fakes/HttpsServerFake.java
@@ -83,7 +83,7 @@ public class HttpsServerFake extends HttpServerFake {
 			KeyManagerFactory keyManagerFactory = 
 					KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
 			keyManagerFactory.init(keyStore, KEYSTORE_PASSWORD.toCharArray());
-			KeyManager keyManagers[] = keyManagerFactory.getKeyManagers();
+			KeyManager[] keyManagers = keyManagerFactory.getKeyManagers();
 			
 			SSLContext sslContext = SSLContext.getInstance("TLS");
 			sslContext.init(keyManagers, null, null);

--- a/src/test/java/com/openshift/client/utils/CartridgeTestUtils.java
+++ b/src/test/java/com/openshift/client/utils/CartridgeTestUtils.java
@@ -126,18 +126,18 @@ public class CartridgeTestUtils {
 	
 	public static IEmbeddableCartridge createObsoleteEmbeddableCartridge(boolean obsolete) {
 		return new EmbeddableCartridge(
-				obsolete == true ? "obsolete-0.1" : "non-obsolete-0.1"
-				, obsolete == true ? "Obsolete 0.1" : "Non-Obsolete 0.1"
-				, obsolete == true ? "Obsolete Cartridge 0.1" : "Non-Obsolete Cartridge 0.1"
+				obsolete ? "obsolete-0.1" : "non-obsolete-0.1"
+				, obsolete ? "Obsolete 0.1" : "Non-Obsolete 0.1"
+				, obsolete ? "Obsolete Cartridge 0.1" : "Non-Obsolete Cartridge 0.1"
 				, obsolete) {
 		};
 	}
 	
 	public static IStandaloneCartridge createObsoleteStandaloneCartridge(boolean obsolete) {
 		return new StandaloneCartridge(
-				obsolete == true ? "obsolete-0.1" : "non-obsolete-0.1"
-				, obsolete == true ? "Obsolete 0.1" : "Non-Obsolete 0.1"
-				, obsolete == true ? "Obsolete Cartridge 0.1" : "Non-Obsolete Cartridge 0.1"
+				obsolete ? "obsolete-0.1" : "non-obsolete-0.1"
+				, obsolete ? "Obsolete 0.1" : "Non-Obsolete 0.1"
+				, obsolete ? "Obsolete Cartridge 0.1" : "Non-Obsolete Cartridge 0.1"
 				, obsolete) {
 
 		};

--- a/src/test/java/com/openshift/internal/client/httpclient/HttpClientTest.java
+++ b/src/test/java/com/openshift/internal/client/httpclient/HttpClientTest.java
@@ -609,9 +609,9 @@ public class HttpClientTest extends TestTimer {
 			public Long call() throws Exception {
 				try {
 					httpClient.get(serverFake.getUrl(), IHttpClient.NO_TIMEOUT);
-					return -1l;
+					return -1L;
 				} catch (SocketTimeoutException e) {
-					return -1l;
+					return -1L;
 				}
 			}
 		});


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:LowerCaseLongSuffixCheck - Long suffix "L" should be upper case. 
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S1125 - Literal boolean values should not be used in condition expressions. 
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:LowerCaseLongSuffixCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1125

Please let me know if you have any questions.

Faisal Hameed