### PR TITLE
Multiple code quality fix-3

### DIFF
--- a/src/main/java/com/openshift/client/ApplicationScale.java
+++ b/src/main/java/com/openshift/client/ApplicationScale.java
@@ -26,7 +26,7 @@ public enum ApplicationScale {
 	
 	public static ApplicationScale safeValueOf(final String value) {
 		if(value == null 
-				|| !SCALING_TRUE.equals(value.toUpperCase())) {
+				|| !SCALING_TRUE.equalsIgnoreCase(value)) {
 			return NO_SCALE;
 		}
 		return SCALE;

--- a/src/main/java/com/openshift/internal/client/RestService.java
+++ b/src/main/java/com/openshift/internal/client/RestService.java
@@ -118,7 +118,7 @@ public class RestService implements IRestService {
         	RestResponse restResponse = getRestResponse(e);
         	String message = getMessage(restResponse, e);
 			throw new OpenShiftEndpointException(
-					url.toString(), e, restResponse, "Could not request {0}: {1}", url, message);
+					url, e, restResponse, "Could not request {0}: {1}", url, message);
         } catch (SocketTimeoutException e) {
             throw new OpenShiftTimeoutException(url, e,
                     "Could not request url {0}, connection timed out", url);

--- a/src/main/java/com/openshift/internal/client/UserResource.java
+++ b/src/main/java/com/openshift/internal/client/UserResource.java
@@ -117,7 +117,7 @@ public class UserResource extends AbstractOpenShiftResource implements IUser {
 
 	@Override
 	public boolean hasDomain() throws OpenShiftException {
-		return (api.getDomains().size() > 0);
+		return api.getDomains().size() > 0;
 	}
 
 	@Override

--- a/src/test/java/com/openshift/internal/client/APIResourceIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/client/APIResourceIntegrationTest.java
@@ -113,7 +113,7 @@ public class APIResourceIntegrationTest extends TestTimer {
 		String domainId = domain.getId();
 		assertThat(domainId).isNotEmpty();
 		IOpenShiftConnection connection = new TestConnectionBuilder().defaultCredentials().disableSSLCertificateChecks().create();
-		APIResource api = ((APIResource) connection);
+		APIResource api = (APIResource) connection;
 		
 		// operation
 		IDomain retrievedDomain = api.showDomain(domainId);

--- a/src/test/java/com/openshift/internal/client/ApplicationResourceTest.java
+++ b/src/test/java/com/openshift/internal/client/ApplicationResourceTest.java
@@ -509,7 +509,7 @@ public class ApplicationResourceTest extends TestTimer {
 		// pre-conditions
 		final IApplication app = domain.getApplicationByName("springeap6");
 		assertThat(app).isNotNull().isInstanceOf(ApplicationResource.class);
-		ApplicationResource spy = Mockito.spy(((ApplicationResource) app));
+		ApplicationResource spy = Mockito.spy((ApplicationResource) app);
 		Mockito.doReturn(false).when(spy).canResolv(Mockito.anyString());
 		long timeout = 2 * 1000;
 		long startTime = System.currentTimeMillis();
@@ -529,7 +529,7 @@ public class ApplicationResourceTest extends TestTimer {
 		long timeout = 10 * 1000;
 		final IApplication app = domain.getApplicationByName("springeap6");
 		assertThat(app).isNotNull().isInstanceOf(ApplicationResource.class);
-		ApplicationResource spy = Mockito.spy(((ApplicationResource) app));
+		ApplicationResource spy = Mockito.spy((ApplicationResource) app);
 		Mockito.doReturn(true).when(spy).canResolv(Mockito.anyString());
 
 		// operation

--- a/src/test/java/com/openshift/internal/client/ApplicationSSHSessionMockDirector.java
+++ b/src/test/java/com/openshift/internal/client/ApplicationSSHSessionMockDirector.java
@@ -32,10 +32,10 @@ public class ApplicationSSHSessionMockDirector {
 
 	public ApplicationSSHSessionMockDirector(IApplication application) throws SocketTimeoutException,
 			HttpClientException, JSchException {
-		ApplicationResource spyedApplication = Mockito.spy(((ApplicationResource) application));
+		ApplicationResource spyedApplication = Mockito.spy((ApplicationResource) application);
 		this.applicationSession =
 				new ApplicationSSHSession(spyedApplication, new JSch().getSession("mockuser", "mockhost", 22));
-		this.spyedApplicationSession = Mockito.spy(((ApplicationSSHSession) applicationSession));
+		this.spyedApplicationSession = Mockito.spy((ApplicationSSHSession) applicationSession);
 		Mockito.doReturn(true)
 				.when(spyedApplicationSession)
 				.isConnected();

--- a/src/test/java/com/openshift/internal/client/ApplicationSSHSessionTest.java
+++ b/src/test/java/com/openshift/internal/client/ApplicationSSHSessionTest.java
@@ -66,10 +66,10 @@ public class ApplicationSSHSessionTest extends TestTimer {
 						+ " java -> 127.7.233.1:9990\n"
 						+ " java -> 127.7.233.1:9999\n"
 						+ " mysql -> 5190d701500446506a0000e4-foobarz.rhcloud.com:56756";
-		ApplicationResource spy = Mockito.spy(((ApplicationResource) app));
+		ApplicationResource spy = Mockito.spy((ApplicationResource) app);
 		final IApplicationSSHSession session =
 				new ApplicationSSHSession(spy, new JSch().getSession("mockuser", "mockhost", 22));
-		ApplicationSSHSession spyedSession = Mockito.spy(((ApplicationSSHSession) session));
+		ApplicationSSHSession spyedSession = Mockito.spy((ApplicationSSHSession) session);
 		Mockito.doReturn(new ByteArrayInputStream(rhcListPortsOutput.getBytes()))
 				.when(spyedSession)
 				.execCommand(Mockito.anyString(), (ApplicationSSHSession.ChannelInputStreams) Mockito.any(),

--- a/src/test/java/com/openshift/internal/client/AuthorizationIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/client/AuthorizationIntegrationTest.java
@@ -98,7 +98,7 @@ public class AuthorizationIntegrationTest extends TestTimer {
 		assertEquals(authorization.getScopes(), IAuthorization.SCOPE_SESSION);
 		assertEquals(authorization.getNote(), "my note");
     		//check for time remaining on the token now
-    		assertTrue((authorization.getExpiresIn() <= 600));
+    		assertTrue(authorization.getExpiresIn() <= 600);
 		
 		authorization.destroy();
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1905 - Redundant casts should not be used
squid:S1858 -  "toString()" should never be called on a String object.
squid:S1157 - Case insensitive string comparisons should be made without intermediate upper or lower casing.
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1905
https://dev.eclipse.org/sonar/rules/show/squid:S1858
https://dev.eclipse.org/sonar/rules/show/squid:S1157

Please let me know if you have any questions.

Faisal Hameed